### PR TITLE
Subgraph support

### DIFF
--- a/ayatori/src/protocol.rs
+++ b/ayatori/src/protocol.rs
@@ -1,5 +1,6 @@
 mod args;
 mod function;
+//mod inner_node;
 mod node;
 mod party;
 mod tag;
@@ -10,7 +11,7 @@ pub(crate) use function::{
     ArrayFunction, ScalarFunction, WrappedArrayFunction, WrappedArrayFunctionPrivate, WrappedScalarFunction,
     WrappedScalarFunctionPrivate,
 };
-pub(crate) use node::{InnerNode, NodeKind, constant};
+pub(crate) use node::{NodeKind, build_protocol, constant};
 pub(crate) use tag::Tag;
 pub(crate) use value::{SerializedValue, Value};
 

--- a/ayatori/src/protocol/args.rs
+++ b/ayatori/src/protocol/args.rs
@@ -20,6 +20,7 @@ pub struct Args<SP: SessionParameters> {
     signer: Arc<SP::Signer>,
     my_id: SP::Verifier,
     values: BTreeMap<String, Value>,
+    shared_data: Option<Value>,
 }
 
 impl<SP: SessionParameters> Args<SP> {
@@ -27,6 +28,7 @@ impl<SP: SessionParameters> Args<SP> {
         signer: &Arc<SP::Signer>,
         my_id: &SP::Verifier,
         values: BTreeMap<Tag, Value>,
+        shared_data: Option<Value>,
     ) -> Result<Self, LocalError> {
         // TODO (#11): for now checking if there are name clashes.
         // If we encounter a situation where we do need arguments with the same name but different TagKind,
@@ -43,6 +45,7 @@ impl<SP: SessionParameters> Args<SP> {
                 .into_iter()
                 .map(|(tag, value)| (tag.name().to_string(), value))
                 .collect(),
+            shared_data,
         })
     }
 
@@ -73,6 +76,9 @@ impl<SP: SessionParameters> Args<SP> {
     }
 
     pub fn get_shared_data<T: Erasable>(&self) -> Result<&T, LocalError> {
-        self.get_value("shared_data")?.downcast_ref::<T>()
+        self.shared_data
+            .as_ref()
+            .ok_or_else(|| LocalError::new("This function was not declared to take shared data"))?
+            .downcast_ref::<T>()
     }
 }

--- a/ayatori/src/protocol/node.rs
+++ b/ayatori/src/protocol/node.rs
@@ -1,4 +1,5 @@
 use alloc::{
+    collections::BTreeMap,
     string::{String, ToString},
     sync::Arc,
     vec::Vec,
@@ -16,82 +17,107 @@ use super::{
     },
     party::PartyGroup,
     tag::Tag,
-    traits::SessionParameters,
+    traits::{Protocol, SessionParameters},
     value::{Erasable, SerdeAdapter, SerializedValue, Value},
 };
 use crate::{error::LocalError, session::SignedValue};
 
-// `Node` intentionally does not implement `Clone` - our clones are shallow, which may be confusing for the user.
-#[derive(Debug)]
-pub struct Node<SP: SessionParameters>(InnerNode<SP>);
-
-impl<SP: SessionParameters> Node<SP> {
-    pub(crate) fn into_inner(self) -> InnerNode<SP> {
-        self.0
-    }
-
-    pub(crate) fn as_inner_ref(&self) -> &InnerNode<SP> {
-        &self.0
-    }
-
-    pub fn group(&self) -> Option<&PartyGroup<SP::Verifier>> {
-        self.0.group()
-    }
-
-    #[must_use]
-    pub fn with_dependencies(self, dependencies: &[&Self]) -> Self {
-        Self(self.0.with_dependencies(dependencies))
-    }
-
-    #[must_use]
-    pub fn store_in(self, name: &str) -> Self {
-        Self(self.0.with_store_in(name))
-    }
+fn nodes_to_owned<'a, SP: SessionParameters>(nodes: impl Iterator<Item = &'a Node<SP>>) -> Vec<Node<SP>> {
+    nodes.map(|node| node.get_strong_ref()).collect()
 }
 
-#[derive(Debug)]
-#[derive_where::derive_where(Clone)]
-pub(crate) struct InnerNode<SP: SessionParameters>(Arc<TypedNode<SP>>);
+fn with_replacements<'a, SP: SessionParameters>(
+    nodes: impl Iterator<Item = &'a Node<SP>>,
+    replacements: &BTreeMap<usize, Node<SP>>,
+) -> Vec<Node<SP>> {
+    nodes
+        .map(|node| replacements.get(&node.id()).unwrap_or(node).get_strong_ref())
+        .collect()
+}
 
-impl<SP: SessionParameters> InnerNode<SP> {
-    pub fn new(typed_node: TypedNode<SP>) -> Self {
+// `Node` intentionally does not implement `Clone` - our clones are shallow, which may be confusing for the user.
+#[derive(Debug)]
+pub struct Node<SP: SessionParameters>(Arc<TypedNode<SP>>);
+
+impl<SP: SessionParameters> Node<SP> {
+    pub(crate) fn new(typed_node: TypedNode<SP>) -> Self {
         Self(Arc::new(typed_node))
     }
 
     #[must_use]
     pub fn with_dependencies(self, dependencies: &[&Node<SP>]) -> Self {
-        let mut typed_node = Arc::unwrap_or_clone(self.0);
-        typed_node.dependencies.extend(nodes_to_owned(dependencies));
-        Self::new(typed_node)
+        let new_node = TypedNode {
+            store_in: self.0.store_in.clone(),
+            kind: self.0.kind.shallow_clone(),
+            dependencies: nodes_to_owned(dependencies.iter().cloned()),
+        };
+        Self::new(new_node)
     }
 
     #[must_use]
     pub fn with_store_in(self, name: &str) -> Self {
-        let mut typed_node = Arc::unwrap_or_clone(self.0);
-        typed_node.store_in = typed_node.store_in.with_name(name);
+        let typed_node = TypedNode {
+            store_in: self.0.store_in.with_name(name),
+            kind: self.0.kind.shallow_clone(),
+            dependencies: nodes_to_owned(self.0.dependencies.iter()),
+        };
         Self::new(typed_node)
     }
 
-    pub fn as_ref(&self) -> &TypedNode<SP> {
-        &self.0
+    pub fn with_shared_data(self) -> Result<Self, LocalError> {
+        let typed_node = TypedNode {
+            store_in: self.0.store_in.clone(),
+            kind: self.0.kind.with_shared_data()?,
+            dependencies: nodes_to_owned(self.0.dependencies.iter()),
+        };
+        Ok(Self::new(typed_node))
     }
 
-    pub fn id(&self) -> usize {
+    pub(crate) fn id(&self) -> usize {
         // A little hacky. Is there a better way?
         Arc::as_ptr(&self.0) as usize
     }
 
-    pub fn group(&self) -> Option<&PartyGroup<SP::Verifier>> {
+    pub(crate) fn group(&self) -> Option<&PartyGroup<SP::Verifier>> {
         self.0.group()
+    }
+
+    pub(crate) fn kind(&self) -> &NodeKind<SP> {
+        self.0.kind()
+    }
+
+    pub(crate) fn store_in(&self) -> &Tag {
+        self.0.store_in()
+    }
+
+    pub fn dependencies(&self) -> &[Node<SP>] {
+        self.0.dependencies()
+    }
+
+    pub(crate) fn get_strong_ref(&self) -> Self {
+        Self(self.0.clone())
+    }
+
+    pub(crate) fn all_dependencies(&self) -> Vec<Self> {
+        self.0.all_dependencies()
+    }
+
+    pub(crate) fn with_replacements(&self, replacements: &BTreeMap<usize, Self>) -> Self {
+        let typed_node = self.0.with_replacements(replacements);
+        Self::new(typed_node)
+    }
+
+    pub(crate) fn finalize(&self, shared_data: &Self) -> Self {
+        let typed_node = self.0.finalize(shared_data);
+        Self::new(typed_node)
     }
 }
 
 #[derive(Debug)]
-#[derive_where::derive_where(Clone)]
 pub(crate) struct TypedNode<SP: SessionParameters> {
     store_in: Tag,
     kind: NodeKind<SP>,
-    dependencies: Vec<InnerNode<SP>>,
+    dependencies: Vec<Node<SP>>,
 }
 
 impl<SP: SessionParameters> TypedNode<SP> {
@@ -99,7 +125,7 @@ impl<SP: SessionParameters> TypedNode<SP> {
         &self.store_in
     }
 
-    pub fn dependencies(&self) -> &[InnerNode<SP>] {
+    pub fn dependencies(&self) -> &[Node<SP>] {
         &self.dependencies
     }
 
@@ -110,28 +136,62 @@ impl<SP: SessionParameters> TypedNode<SP> {
     pub fn kind(&self) -> &NodeKind<SP> {
         &self.kind
     }
+
+    pub fn all_dependencies(&self) -> Vec<Node<SP>> {
+        let mut all_dependencies = nodes_to_owned(self.dependencies.iter());
+        all_dependencies.extend(self.kind.all_dependencies());
+        all_dependencies
+    }
+
+    pub fn with_replacements(&self, replacements: &BTreeMap<usize, Node<SP>>) -> Self {
+        let mut kind = self.kind.shallow_clone();
+        kind.replace_nodes(replacements);
+        Self {
+            store_in: self.store_in.clone(),
+            kind,
+            dependencies: with_replacements(self.dependencies.iter(), replacements),
+        }
+    }
+
+    pub fn finalize(&self, shared_data: &Node<SP>) -> Self {
+        Self {
+            store_in: self.store_in.clone(),
+            kind: self.kind.finalize(shared_data),
+            dependencies: nodes_to_owned(self.dependencies.iter()),
+        }
+    }
 }
 
 #[derive(Debug)]
-#[derive_where::derive_where(Clone)]
 pub(crate) enum NodeKind<SP: SessionParameters> {
+    ComputeScalarWithPlaceholders {
+        function: ScalarFunction<SP>,
+        args: Vec<Node<SP>>,
+        uses_shared_data: bool,
+    },
+    ComputeArrayWithPlaceholders {
+        function: ArrayFunction<SP>,
+        group: PartyGroup<SP::Verifier>,
+        args: Vec<Node<SP>>,
+        uses_shared_data: bool,
+    },
     ComputeScalar {
         function: ScalarFunction<SP>,
-        args: Vec<InnerNode<SP>>,
+        args: Vec<Node<SP>>,
+        shared_data: Option<Node<SP>>,
     },
     ComputeArray {
         function: ArrayFunction<SP>,
-        #[allow(unused)] // TODO (#9): to be used when we implement short-circuiting
-        returns_nothing: bool,
         group: PartyGroup<SP::Verifier>,
-        args: Vec<InnerNode<SP>>,
+        args: Vec<Node<SP>>,
+        shared_data: Option<Node<SP>>,
     },
     DirectMessage {
-        data: InnerNode<SP>,
+        data: Node<SP>,
         group: PartyGroup<SP::Verifier>,
     },
     Collect {
-        values: InnerNode<SP>,
+        values: Node<SP>,
         group: PartyGroup<SP::Verifier>,
     },
     Receive {
@@ -139,24 +199,166 @@ pub(crate) enum NodeKind<SP: SessionParameters> {
     },
 }
 
-fn nodes_to_owned<SP: SessionParameters>(nodes: &[&Node<SP>]) -> impl Iterator<Item = InnerNode<SP>> {
-    nodes.iter().map(|node| node.as_inner_ref().clone())
-}
-
 impl<SP: SessionParameters> NodeKind<SP> {
+    pub fn shallow_clone(&self) -> Self {
+        match self {
+            Self::ComputeScalarWithPlaceholders {
+                function,
+                args,
+                uses_shared_data,
+            } => Self::ComputeScalarWithPlaceholders {
+                function: function.clone(),
+                args: nodes_to_owned(args.iter()),
+                uses_shared_data: *uses_shared_data,
+            },
+            Self::ComputeArrayWithPlaceholders {
+                function,
+                group,
+                args,
+                uses_shared_data,
+            } => Self::ComputeArrayWithPlaceholders {
+                function: function.clone(),
+                group: group.clone(),
+                args: nodes_to_owned(args.iter()),
+                uses_shared_data: *uses_shared_data,
+            },
+            Self::ComputeScalar {
+                function,
+                args,
+                shared_data,
+            } => Self::ComputeScalar {
+                function: function.clone(),
+                args: nodes_to_owned(args.iter()),
+                shared_data: shared_data.as_ref().map(Node::get_strong_ref),
+            },
+            Self::ComputeArray {
+                function,
+                group,
+                args,
+                shared_data,
+            } => Self::ComputeArray {
+                function: function.clone(),
+                group: group.clone(),
+                args: nodes_to_owned(args.iter()),
+                shared_data: shared_data.as_ref().map(Node::get_strong_ref),
+            },
+            Self::DirectMessage { data, group } => Self::DirectMessage {
+                data: data.get_strong_ref(),
+                group: group.clone(),
+            },
+            Self::Collect { values, group } => Self::Collect {
+                values: values.get_strong_ref(),
+                group: group.clone(),
+            },
+            Self::Receive { group } => Self::Receive { group: group.clone() },
+        }
+    }
+
+    pub fn all_dependencies(&self) -> Vec<Node<SP>> {
+        match self {
+            Self::ComputeScalar { args, .. }
+            | Self::ComputeArray { args, .. }
+            | Self::ComputeScalarWithPlaceholders { args, .. }
+            | Self::ComputeArrayWithPlaceholders { args, .. } => nodes_to_owned(args.iter()),
+            Self::Collect { values, .. } => [values.get_strong_ref()].into(),
+            Self::DirectMessage { data, .. } => [data.get_strong_ref()].into(),
+            Self::Receive { .. } => Vec::new(),
+        }
+    }
+
+    pub fn replace_nodes(&mut self, replacements: &BTreeMap<usize, Node<SP>>) {
+        match self {
+            Self::ComputeScalar { args, .. } => *args = with_replacements(args.iter(), replacements),
+            Self::ComputeArray { args, .. } => *args = with_replacements(args.iter(), replacements),
+            Self::ComputeScalarWithPlaceholders { args, .. } => *args = with_replacements(args.iter(), replacements),
+            Self::ComputeArrayWithPlaceholders { args, .. } => *args = with_replacements(args.iter(), replacements),
+            Self::Collect { values, .. } => *values = replacements.get(&values.id()).unwrap_or(values).get_strong_ref(),
+            Self::DirectMessage { data, .. } => *data = replacements.get(&data.id()).unwrap_or(data).get_strong_ref(),
+            Self::Receive { .. } => {}
+        }
+    }
+
+    pub fn finalize(&self, shared_data: &Node<SP>) -> Self {
+        match self {
+            Self::ComputeScalarWithPlaceholders {
+                uses_shared_data,
+                args,
+                function,
+            } => {
+                let shared_data = if *uses_shared_data {
+                    Some(shared_data.get_strong_ref())
+                } else {
+                    None
+                };
+                Self::ComputeScalar {
+                    shared_data,
+                    args: nodes_to_owned(args.iter()),
+                    function: function.clone(),
+                }
+            }
+            Self::ComputeArrayWithPlaceholders {
+                uses_shared_data,
+                args,
+                function,
+                group,
+            } => {
+                let shared_data = if *uses_shared_data {
+                    Some(shared_data.get_strong_ref())
+                } else {
+                    None
+                };
+                Self::ComputeArray {
+                    shared_data,
+                    args: nodes_to_owned(args.iter()),
+                    function: function.clone(),
+                    group: group.clone(),
+                }
+            }
+            _ => self.shallow_clone(),
+        }
+    }
+
     pub fn group(&self) -> Option<&PartyGroup<SP::Verifier>> {
         match self {
-            Self::ComputeArray { group, .. } | Self::DirectMessage { group, .. } | Self::Receive { group, .. } => {
-                Some(group)
-            }
-            Self::Collect { .. } | Self::ComputeScalar { .. } => None,
+            Self::ComputeArrayWithPlaceholders { group, .. }
+            | Self::ComputeArray { group, .. }
+            | Self::DirectMessage { group, .. }
+            | Self::Receive { group, .. } => Some(group),
+            Self::Collect { .. } | Self::ComputeScalar { .. } | Self::ComputeScalarWithPlaceholders { .. } => None,
+        }
+    }
+
+    pub fn with_shared_data(&self) -> Result<Self, LocalError> {
+        // TODO: disallow double call to `with_shared_data()`
+        match self {
+            Self::ComputeScalarWithPlaceholders {
+                function,
+                args,
+                uses_shared_data: _uses_shared_data,
+            } => Ok(Self::ComputeScalarWithPlaceholders {
+                function: function.clone(),
+                args: nodes_to_owned(args.iter()),
+                uses_shared_data: true,
+            }),
+            Self::ComputeArrayWithPlaceholders {
+                function,
+                group,
+                args,
+                uses_shared_data: _uses_shared_data,
+            } => Ok(Self::ComputeArrayWithPlaceholders {
+                function: function.clone(),
+                group: group.clone(),
+                args: nodes_to_owned(args.iter()),
+                uses_shared_data: true,
+            }),
+            _ => Err(LocalError::new("This node does not use shared data")),
         }
     }
 }
 
 pub(crate) fn constant<SP: SessionParameters, Ret: Erasable>(name: &str, value: Ret) -> Node<SP> {
     let erased_value = Value::new(value);
-    let inner = TypedNode {
+    Node::new(TypedNode {
         store_in: Tag::computed(name),
         dependencies: Vec::new(),
         kind: NodeKind::ComputeScalar {
@@ -164,9 +366,9 @@ pub(crate) fn constant<SP: SessionParameters, Ret: Erasable>(name: &str, value: 
                 Ok(erased_value.clone())
             })),
             args: Vec::new(),
+            shared_data: None,
         },
-    };
-    Node(InnerNode::new(inner))
+    })
 }
 
 pub fn compute_scalar<SP: SessionParameters, Ret: Erasable>(
@@ -174,15 +376,15 @@ pub fn compute_scalar<SP: SessionParameters, Ret: Erasable>(
     function: impl 'static + Fn(Args<SP>) -> Result<Ret, ComputeError>,
     args: &[&Node<SP>],
 ) -> Result<Node<SP>, LocalError> {
-    let inner = TypedNode {
+    Ok(Node::new(TypedNode {
         store_in: Tag::computed(name),
         dependencies: Vec::new(),
-        kind: NodeKind::ComputeScalar {
+        kind: NodeKind::ComputeScalarWithPlaceholders {
             function: ScalarFunction::Public(WrappedScalarFunction::new(function)),
-            args: nodes_to_owned(args).collect(),
+            args: nodes_to_owned(args.iter().cloned()),
+            uses_shared_data: false,
         },
-    };
-    Ok(Node(InnerNode::new(inner)))
+    }))
 }
 
 pub fn compute_scalar_private<SP: SessionParameters, Ret: Erasable>(
@@ -190,15 +392,15 @@ pub fn compute_scalar_private<SP: SessionParameters, Ret: Erasable>(
     function: impl 'static + Fn(&mut dyn CryptoRngCore, Args<SP>) -> Result<Ret, ComputeError>,
     args: &[&Node<SP>],
 ) -> Result<Node<SP>, LocalError> {
-    let inner = TypedNode {
+    Ok(Node::new(TypedNode {
         store_in: Tag::computed(name),
         dependencies: Vec::new(),
-        kind: NodeKind::ComputeScalar {
+        kind: NodeKind::ComputeScalarWithPlaceholders {
             function: ScalarFunction::Private(WrappedScalarFunctionPrivate::new(function)),
-            args: nodes_to_owned(args).collect(),
+            args: nodes_to_owned(args.iter().cloned()),
+            uses_shared_data: false,
         },
-    };
-    Ok(Node(InnerNode::new(inner)))
+    }))
 }
 
 pub fn compute_array<SP: SessionParameters, Ret: Erasable>(
@@ -207,17 +409,16 @@ pub fn compute_array<SP: SessionParameters, Ret: Erasable>(
     group: &PartyGroup<SP::Verifier>,
     args: &[&Node<SP>],
 ) -> Result<Node<SP>, LocalError> {
-    let inner = TypedNode {
+    Ok(Node::new(TypedNode {
         store_in: Tag::computed(name),
         dependencies: Vec::new(),
-        kind: NodeKind::ComputeArray {
-            returns_nothing: false,
+        kind: NodeKind::ComputeArrayWithPlaceholders {
             function: ArrayFunction::Public(WrappedArrayFunction::new(function)),
             group: group.clone(),
-            args: nodes_to_owned(args).collect(),
+            args: nodes_to_owned(args.iter().cloned()),
+            uses_shared_data: false,
         },
-    };
-    Ok(Node(InnerNode::new(inner)))
+    }))
 }
 
 pub fn compute_array_private<SP: SessionParameters, Ret: Erasable>(
@@ -226,17 +427,16 @@ pub fn compute_array_private<SP: SessionParameters, Ret: Erasable>(
     group: &PartyGroup<SP::Verifier>,
     args: &[&Node<SP>],
 ) -> Result<Node<SP>, LocalError> {
-    let inner = TypedNode {
+    Ok(Node::new(TypedNode {
         store_in: Tag::computed(name),
         dependencies: Vec::new(),
-        kind: NodeKind::ComputeArray {
-            returns_nothing: false,
+        kind: NodeKind::ComputeArrayWithPlaceholders {
             function: ArrayFunction::Private(WrappedArrayFunctionPrivate::new(function)),
             group: group.clone(),
-            args: nodes_to_owned(args).collect(),
+            args: nodes_to_owned(args.iter().cloned()),
+            uses_shared_data: false,
         },
-    };
-    Ok(Node(InnerNode::new(inner)))
+    }))
 }
 
 pub fn verify<SP: SessionParameters>(
@@ -253,17 +453,7 @@ pub fn verify<SP: SessionParameters>(
         return Err(LocalError::new("The group of all arguments must be the same"));
     }
 
-    let inner = TypedNode {
-        store_in: Tag::computed(name),
-        dependencies: Vec::new(),
-        kind: NodeKind::ComputeArray {
-            function: ArrayFunction::Public(WrappedArrayFunction::new(function)),
-            returns_nothing: true,
-            group: group.clone(),
-            args: nodes_to_owned(args).collect(),
-        },
-    };
-    Ok(Node(InnerNode::new(inner)))
+    compute_array(name, function, group, args)
 }
 
 /// A wrapper to convert `dyn CryptoRngCore` to a sized `impl CryptoRngCore`,
@@ -306,9 +496,8 @@ pub fn broadcast<SP: SessionParameters>(
     scalar: &Node<SP>,
     group: &PartyGroup<SP::Verifier>,
 ) -> Result<Node<SP>, LocalError> {
-    let scalar = scalar.as_inner_ref().clone();
     let cloned_message = message.clone();
-    let value_name = scalar.as_ref().store_in().name().to_string();
+    let value_name = scalar.store_in().name().to_string();
 
     if scalar.group().is_some() {
         return Err(LocalError::new(
@@ -316,69 +505,67 @@ pub fn broadcast<SP: SessionParameters>(
         ));
     }
 
-    let serialize_and_sign = InnerNode::new(TypedNode {
+    let serialize_and_sign = Node::new(TypedNode {
         store_in: Tag::signed(&message.name),
         dependencies: Vec::new(),
         kind: NodeKind::ComputeArray {
-            args: [scalar].into(),
+            args: [scalar.get_strong_ref()].into(),
             function: ArrayFunction::Private(WrappedArrayFunctionPrivate::new_pre_erased(
                 "serialize",
                 move |rng: &mut dyn CryptoRngCore, id: &SP::Verifier, args: Args<SP>| {
                     serialize::<SP>(rng, id, value_name.to_string(), args, &cloned_message)
                 },
             )),
-            returns_nothing: false,
+            shared_data: None,
             group: group.clone(),
         },
     });
 
-    let send_node = Node(InnerNode::new(TypedNode {
+    let send_node = Node::new(TypedNode {
         store_in: Tag::sent(&message.name),
         dependencies: Vec::new(),
         kind: NodeKind::DirectMessage {
             data: serialize_and_sign,
             group: group.clone(),
         },
-    }));
+    });
 
     collect(&send_node)
 }
 
 pub fn send<SP: SessionParameters>(message: &ProtocolMessage<SP>, array: &Node<SP>) -> Result<Node<SP>, LocalError> {
-    let array = array.as_inner_ref().clone();
     let cloned_message = message.clone();
-    let value_name = array.as_ref().store_in().name().to_string();
+    let value_name = array.store_in().name().to_string();
 
     let group = array
-        .as_ref()
         .group()
         .ok_or_else(|| LocalError::new("`array` argument of `send()` must be an array node"))?
         .clone();
 
-    let serialize_and_sign = InnerNode::new(TypedNode {
+    let serialize_and_sign = Node::new(TypedNode {
         store_in: Tag::signed(&message.name),
         dependencies: Vec::new(),
         kind: NodeKind::ComputeArray {
-            args: [array].into(),
+            args: [array.get_strong_ref()].into(),
             function: ArrayFunction::Private(WrappedArrayFunctionPrivate::new_pre_erased(
                 "serialize",
                 move |rng: &mut dyn CryptoRngCore, id: &SP::Verifier, args: Args<SP>| {
                     serialize::<SP>(rng, id, value_name.clone(), args, &cloned_message)
                 },
             )),
-            returns_nothing: false,
+            shared_data: None,
             group: group.clone(),
         },
     });
 
-    let send_node = Node(InnerNode::new(TypedNode {
+    let send_node = Node::new(TypedNode {
         store_in: Tag::sent(&message.name),
         dependencies: Vec::new(),
         kind: NodeKind::DirectMessage {
             data: serialize_and_sign,
             group,
         },
-    }));
+    });
 
     collect(&send_node)
 }
@@ -392,7 +579,7 @@ fn deserialize<SP: SessionParameters>(args: Args<SP>, message: &ProtocolMessage<
 }
 
 pub fn receive<SP: SessionParameters>(message: &ProtocolMessage<SP>, group: &PartyGroup<SP::Verifier>) -> Node<SP> {
-    let received = InnerNode::new(TypedNode {
+    let received = Node::new(TypedNode {
         store_in: Tag::received(&message.name),
         dependencies: Vec::new(),
         kind: NodeKind::Receive { group: group.clone() },
@@ -400,7 +587,7 @@ pub fn receive<SP: SessionParameters>(message: &ProtocolMessage<SP>, group: &Par
 
     let cloned_message = message.clone();
 
-    Node(InnerNode::new(TypedNode {
+    Node::new(TypedNode {
         store_in: Tag::deserialized(&message.name),
         dependencies: Vec::new(),
         kind: NodeKind::ComputeArray {
@@ -409,25 +596,26 @@ pub fn receive<SP: SessionParameters>(message: &ProtocolMessage<SP>, group: &Par
                 "deserialize",
                 move |_id: &SP::Verifier, args: Args<SP>| deserialize::<SP>(args, &cloned_message),
             )),
-            returns_nothing: false,
+            shared_data: None,
             group: group.clone(),
         },
-    }))
+    })
 }
 
 pub fn collect<SP: SessionParameters>(values: &Node<SP>) -> Result<Node<SP>, LocalError> {
-    let values = values.as_inner_ref().clone();
     let group = values
-        .as_ref()
         .group()
         .ok_or_else(|| LocalError::new("`values` argument of `collect()` must be an array node"))?
         .clone();
 
-    Ok(Node(InnerNode::new(TypedNode {
-        store_in: Tag::collected(&values.as_ref().store_in),
+    Ok(Node::new(TypedNode {
+        store_in: Tag::collected(values.store_in()),
         dependencies: Vec::new(),
-        kind: NodeKind::Collect { values, group },
-    })))
+        kind: NodeKind::Collect {
+            values: values.get_strong_ref(),
+            group,
+        },
+    }))
 }
 
 #[derive(Debug)]
@@ -444,4 +632,49 @@ impl<SP: SessionParameters> ProtocolMessage<SP> {
             serde_adapter: SerdeAdapter::new::<T>(),
         }
     }
+}
+
+fn finalize_nodes<SP: SessionParameters>(root: Node<SP>, shared_data: &Node<SP>) -> Node<SP> {
+    let root_id = root.id();
+    let mut nodes_to_process: Vec<_> = [root.get_strong_ref()].into();
+    let mut replacement_nodes = BTreeMap::new();
+
+    while let Some(node) = nodes_to_process.pop() {
+        if replacement_nodes.contains_key(&node.id()) {
+            continue;
+        }
+
+        let all_dependencies = node.all_dependencies();
+
+        if all_dependencies
+            .iter()
+            .all(|dependency| replacement_nodes.contains_key(&dependency.id()))
+        {
+            let new_node = node.with_replacements(&replacement_nodes);
+            let new_node = new_node.finalize(shared_data);
+
+            // TODO: or only save modified nodes?
+            replacement_nodes.insert(node.id(), new_node);
+        } else {
+            nodes_to_process.push(node);
+            nodes_to_process.extend(all_dependencies.iter().filter_map(|dependency| {
+                if replacement_nodes.contains_key(&dependency.id()) {
+                    None
+                } else {
+                    Some(dependency.get_strong_ref())
+                }
+            }));
+        }
+    }
+
+    replacement_nodes.get(&root_id).expect("we processed the root node").get_strong_ref()
+}
+
+pub(crate) fn build_protocol<SP: SessionParameters, P: Protocol<SP>>(
+    my_id: &SP::Verifier,
+    build_data: &P::BuildData,
+    shared_data: &Node<SP>,
+) -> Result<Node<SP>, LocalError> {
+    let node = P::build(my_id, build_data)?;
+    Ok(finalize_nodes(node, shared_data))
 }

--- a/ayatori/src/protocol/traits.rs
+++ b/ayatori/src/protocol/traits.rs
@@ -55,9 +55,5 @@ pub trait Protocol<SP: SessionParameters>: Sized + Debug {
     // TODO: we may not need `Clone` here
     type Output: 'static + Clone + Erasable;
 
-    fn build(
-        my_id: &SP::Verifier,
-        build_data: &Self::BuildData,
-        shared_data: &Node<SP>,
-    ) -> Result<Node<SP>, LocalError>;
+    fn build(my_id: &SP::Verifier, build_data: &Self::BuildData) -> Result<Node<SP>, LocalError>;
 }

--- a/ayatori/src/session/ruleset.rs
+++ b/ayatori/src/session/ruleset.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use super::conditions::{Condition, LeafCondition};
 use crate::{
     error::LocalError,
-    protocol::{ArrayFunction, InnerNode, Node, NodeKind, ScalarFunction, SessionParameters, Tag},
+    protocol::{ArrayFunction, Node, NodeKind, ScalarFunction, SessionParameters, Tag},
 };
 
 #[derive(Debug)]
@@ -21,12 +21,14 @@ pub(crate) enum Action<SP: SessionParameters> {
         store_in: Tag,
         function: ScalarFunction<SP>,
         args: Vec<Tag>,
+        shared_data: Option<Tag>,
     },
     ComputeArrayElement {
         store_in: Tag,
         index: SP::Verifier,
         function: ArrayFunction<SP>,
         args: Vec<Arg>,
+        shared_data: Option<Tag>,
     },
     Send {
         store_in: Tag,
@@ -54,8 +56,7 @@ pub(crate) struct Ruleset<SP: SessionParameters> {
 
 impl<SP: SessionParameters> Ruleset<SP> {
     pub fn new(output_node: Node<SP>) -> Result<Self, LocalError> {
-        let output_node = output_node.into_inner();
-        let output_tag = output_node.as_ref().store_in().clone();
+        let output_tag = output_node.store_in().clone();
 
         let mut nodes_to_process = vec![output_node];
         let mut rules = Vec::new();
@@ -68,45 +69,47 @@ impl<SP: SessionParameters> Ruleset<SP> {
             }
             nodes_seen.insert(node.id());
 
-            if let NodeKind::Receive { .. } = node.as_ref().kind() {
+            if let NodeKind::Receive { .. } = node.kind() {
                 continue;
             }
 
             let mut shared_condition = Condition::empty();
 
-            for dependency in node.as_ref().dependencies() {
-                match dependency.as_ref().group() {
+            for dependency in node.dependencies() {
+                match dependency.group() {
                     Some(_group) => {
                         return Err(LocalError::new("Only scalar nodes are allowed as dependencies"));
                     }
                     None => {
                         shared_condition.and(LeafCondition::Value {
-                            tag: dependency.as_ref().store_in().clone(),
+                            tag: dependency.store_in().clone(),
                         });
                     }
                 }
-                nodes_to_process.push(dependency.clone());
+                nodes_to_process.push(dependency.get_strong_ref());
             }
 
             let mut actions = Vec::new();
 
-            match node.as_ref().kind() {
-                NodeKind::ComputeScalar { function, args } => {
+            match node.kind() {
+                NodeKind::ComputeScalar {
+                    function,
+                    args,
+                    shared_data,
+                } => {
                     let mut specific_condition = Condition::empty();
                     for arg in args {
                         specific_condition.and(LeafCondition::Value {
-                            tag: arg.as_ref().store_in().clone(),
+                            tag: arg.store_in().clone(),
                         });
-                        nodes_to_process.push(arg.clone());
+                        nodes_to_process.push(arg.get_strong_ref());
                     }
                     actions.push((
                         Action::ComputeScalar {
-                            store_in: node.as_ref().store_in().clone(),
+                            store_in: node.store_in().clone(),
                             function: function.clone(),
-                            args: args
-                                .iter()
-                                .map(|arg: &InnerNode<SP>| arg.as_ref().store_in().clone())
-                                .collect(),
+                            args: args.iter().map(|arg: &Node<SP>| arg.store_in().clone()).collect(),
+                            shared_data: shared_data.as_ref().map(|node| node.store_in().clone()),
                         },
                         specific_condition,
                     ));
@@ -115,58 +118,58 @@ impl<SP: SessionParameters> Ruleset<SP> {
                     function,
                     args,
                     group,
-                    #[allow(unused)]
-                    returns_nothing,
+                    shared_data,
                 } => {
                     for id in group.ids() {
                         let mut specific_condition = Condition::empty();
                         for arg in args {
-                            if arg.as_ref().group().is_some() {
+                            if arg.group().is_some() {
                                 specific_condition.and(LeafCondition::ArrayElement {
-                                    tag: arg.as_ref().store_in().clone(),
+                                    tag: arg.store_in().clone(),
                                     id: id.clone(),
                                 });
                             } else {
                                 specific_condition.and(LeafCondition::Value {
-                                    tag: arg.as_ref().store_in().clone(),
+                                    tag: arg.store_in().clone(),
                                 });
                             }
-                            nodes_to_process.push(arg.clone());
+                            nodes_to_process.push(arg.get_strong_ref());
                         }
 
                         actions.push((
                             Action::ComputeArrayElement {
-                                store_in: node.as_ref().store_in().clone(),
+                                store_in: node.store_in().clone(),
                                 function: function.clone(),
                                 index: id.clone(),
                                 args: args
                                     .iter()
-                                    .map(|arg: &InnerNode<SP>| {
-                                        let tag = arg.as_ref().store_in().clone();
-                                        if arg.as_ref().group().is_some() {
+                                    .map(|arg: &Node<SP>| {
+                                        let tag = arg.store_in().clone();
+                                        if arg.group().is_some() {
                                             Arg::ArrayElem(tag)
                                         } else {
                                             Arg::Scalar(tag)
                                         }
                                     })
                                     .collect(),
+                                shared_data: shared_data.as_ref().map(|node| node.store_in().clone()),
                             },
                             specific_condition,
                         ));
                     }
                 }
                 NodeKind::DirectMessage { data, group } => {
-                    nodes_to_process.push(data.clone());
+                    nodes_to_process.push(data.get_strong_ref());
                     for id in group.ids() {
                         let mut specific_condition = Condition::empty();
                         specific_condition.and(LeafCondition::ArrayElement {
-                            tag: data.as_ref().store_in().clone(),
+                            tag: data.store_in().clone(),
                             id: id.clone(),
                         });
                         actions.push((
                             Action::Send {
-                                store_in: node.as_ref().store_in().clone(),
-                                to_send: data.as_ref().store_in().clone(),
+                                store_in: node.store_in().clone(),
+                                to_send: data.store_in().clone(),
                                 destination: id.clone(),
                                 index: Some(id.clone()),
                             },
@@ -177,21 +180,26 @@ impl<SP: SessionParameters> Ruleset<SP> {
                 NodeKind::Collect { values, group } => {
                     let mut specific_condition = Condition::empty();
                     specific_condition.and(LeafCondition::Array {
-                        tag: values.as_ref().store_in().clone(),
+                        tag: values.store_in().clone(),
                         group: group.clone(),
                         got_ids: BTreeSet::new(),
                     });
-                    nodes_to_process.push(values.clone());
+                    nodes_to_process.push(values.get_strong_ref());
 
                     actions.push((
                         Action::Collect {
-                            store_in: node.as_ref().store_in().clone(),
-                            values: values.as_ref().store_in().clone(),
+                            store_in: node.store_in().clone(),
+                            values: values.store_in().clone(),
                         },
                         specific_condition,
                     ));
                 }
                 NodeKind::Receive { .. } => {}
+                NodeKind::ComputeScalarWithPlaceholders { .. } | NodeKind::ComputeArrayWithPlaceholders { .. } => {
+                    return Err(LocalError::new(
+                        "Placeholder nodes were encountered at rule building stage",
+                    ));
+                }
             }
 
             for (action, specific_condition) in actions {
@@ -254,15 +262,17 @@ impl<SP: SessionParameters> Display for Action<SP> {
                 store_in,
                 function,
                 args,
+                shared_data,
             } => {
                 let joined_args = args.iter().map(ToString::to_string).join(", ");
-                write!(f, "{store_in} = {function}({joined_args})")
+                write!(f, "{store_in} = {function}({joined_args}), shared: {shared_data:?}")
             }
             Self::ComputeArrayElement {
                 store_in,
                 index,
                 function,
                 args,
+                shared_data,
             } => {
                 let joined_args = args
                     .iter()
@@ -271,7 +281,10 @@ impl<SP: SessionParameters> Display for Action<SP> {
                         Arg::ArrayElem(tag) => format!("{tag}[{index:?}]"),
                     })
                     .join(", ");
-                write!(f, "{store_in}[{index:?}] = {function}({index:?}, {joined_args})")
+                write!(
+                    f,
+                    "{store_in}[{index:?}] = {function}({index:?}, {joined_args}), shared: {shared_data:?}"
+                )
             }
             Self::Send {
                 store_in,

--- a/ayatori/src/session/session.rs
+++ b/ayatori/src/session/session.rs
@@ -12,7 +12,7 @@ use crate::{
     protocol::{
         Args, ArrayFunction, ComputeError, Erasable, PartyId, Protocol, ScalarFunction, SessionParameters, Tag, Value,
         WrappedArrayFunction, WrappedArrayFunctionPrivate, WrappedScalarFunction, WrappedScalarFunctionPrivate,
-        constant,
+        build_protocol, constant,
     },
 };
 
@@ -240,7 +240,7 @@ where
     pub fn new(signer: SP::Signer, build_data: &P::BuildData, shared_data: P::SharedData) -> Result<Self, LocalError> {
         // TODO: make sure there are no name clashes. Special tag type?
         let input_node = constant("input", shared_data);
-        let output_node = P::build(&signer.verifying_key(), build_data, &input_node)?;
+        let output_node = build_protocol::<SP, P>(&signer.verifying_key(), build_data, &input_node)?;
         let ruleset = Ruleset::new(output_node)?;
         let storage = Storage::new();
         let signer = Arc::new(signer);
@@ -295,12 +295,14 @@ where
                     store_in,
                     function,
                     args,
+                    shared_data,
                 } => {
                     let arg_values = args
                         .iter()
                         .map(|tag: &Tag| self.storage.get(tag).map(|value| (tag.clone(), value)))
                         .collect::<Result<BTreeMap<_, _>, LocalError>>()?;
-                    let args = Args::new(&self.signer, &self.id(), arg_values)?;
+                    let shared_data = shared_data.as_ref().map(|tag| self.storage.get(tag)).transpose()?;
+                    let args = Args::new(&self.signer, &self.id(), arg_values, shared_data)?;
                     match function {
                         ScalarFunction::Public(function) => {
                             return Ok(Some(Task::Compute(ComputeTask {
@@ -323,6 +325,7 @@ where
                     function,
                     index,
                     args,
+                    shared_data,
                 } => {
                     let arg_values = args
                         .iter()
@@ -331,7 +334,8 @@ where
                             Arg::ArrayElem(tag) => self.storage.get_elem(tag, &index).map(|value| (tag.clone(), value)),
                         })
                         .collect::<Result<BTreeMap<_, _>, LocalError>>()?;
-                    let args = Args::new(&self.signer, &self.id(), arg_values)?;
+                    let shared_data = shared_data.as_ref().map(|tag| self.storage.get(tag)).transpose()?;
+                    let args = Args::new(&self.signer, &self.id(), arg_values, shared_data)?;
                     match function {
                         ArrayFunction::Public(function) => {
                             return Ok(Some(Task::Compute(ComputeTask {

--- a/ayatori/src/tests/distributed_rng.rs
+++ b/ayatori/src/tests/distributed_rng.rs
@@ -44,11 +44,7 @@ impl<SP: SessionParameters> Protocol<SP> for DistributedRNG {
     type SharedData = ();
     type BuildData = PartyGroup<SP::Verifier>;
     type Output = u64;
-    fn build(
-        _my_id: &SP::Verifier,
-        build_data: &Self::BuildData,
-        _shared_data: &Node<SP>,
-    ) -> Result<Node<SP>, LocalError> {
+    fn build(_my_id: &SP::Verifier, build_data: &Self::BuildData) -> Result<Node<SP>, LocalError> {
         let message_b = ProtocolMessage::new::<u64>("b");
         let message_r = ProtocolMessage::new::<u64>("r");
         let message_c = ProtocolMessage::new::<u64>("c");

--- a/ayatori/src/tests/messages.rs
+++ b/ayatori/src/tests/messages.rs
@@ -65,11 +65,7 @@ impl<SP: SessionParameters> Protocol<SP> for TestProtocol {
     type BuildData = PartyGroup<SP::Verifier>;
     type SharedData = ();
     type Output = ();
-    fn build(
-        my_id: &SP::Verifier,
-        build_data: &Self::BuildData,
-        _shared_data: &Node<SP>,
-    ) -> Result<Node<SP>, LocalError> {
+    fn build(my_id: &SP::Verifier, build_data: &Self::BuildData) -> Result<Node<SP>, LocalError> {
         let message_x = ProtocolMessage::new::<Message1<SP::Verifier>>("x");
         let message_y = ProtocolMessage::new::<Message2<SP::Verifier>>("y");
         let message_z = ProtocolMessage::new::<Message3<SP::Verifier>>("z");


### PR DESCRIPTION
Fixes #17

TODO
- Should we mix "finalized" and "nonfinalized" nodes? Separating them will make the types clearer, but there will be some duplication.
- Too much cloning going on, make some methods consume `self`?
- Actual subgraph functionality to be added
- Add Display for node trees, and "shallow display" to just show one node without expanding the dependencies