### PR TITLE
Error traceback

### DIFF
--- a/ayatori/src/dev/replacements.rs
+++ b/ayatori/src/dev/replacements.rs
@@ -6,9 +6,9 @@ use signature::rand_core::CryptoRngCore;
 use crate::{
     entities::{
         AnyTag, Args, ComputedMappingTag, ComputedScalarTag, Erasable, FullName, LocalSignedTag, MappingTag,
-        RuntimeError, ScalarFunction, ScalarTag, SerializeAndSignFunction, SerializeArgs, SignedValue,
-        SimpleMappingFunction, ThirdPartyAttributableError, ThirdPartyAttributableMappingFunction, UnattributableError,
-        UnattributableMappingFunction, UnattributableScalarFunction, Value,
+        MaybeAttributableError, RuntimeError, ScalarFunction, ScalarTag, SerializeAndSignFunction, SerializeArgs,
+        SignedValue, SimpleMappingFunction, ThirdPartyAttributableMappingFunction, ThirdPartyError,
+        UnattributableError, UnattributableMappingFunction, UnattributableScalarFunction, Value,
     },
     error::TraceableResult,
     graph_representation::{AnyNode, ComputeMappingKind, GeneralizedNode, OutputNode, ShallowClone},
@@ -50,10 +50,10 @@ enum ReplacementEnum<SP: SessionParameters> {
     ComputeMappingThirdPartyAttributable {
         function: Arc<
             dyn Fn(
-                    Result<Value, ThirdPartyAttributableError<SP>>,
+                    Result<Value, MaybeAttributableError<ThirdPartyError<SP>>>,
                     &SP::Verifier,
                     &Args<SP>,
-                ) -> Result<Value, ThirdPartyAttributableError<SP>>
+                ) -> Result<Value, MaybeAttributableError<ThirdPartyError<SP>>>
                 + Send
                 + Sync,
         >,
@@ -105,7 +105,7 @@ impl<SP: SessionParameters> Replacement<SP> {
         Ok(Self {
             tag: AnyTag::Mapping(MappingTag::Computed(tag.clone())),
             kind: ReplacementEnum::ComputeMapping {
-                function: Arc::new(move |value: Value, id, args| {
+                function: Arc::new(move |value, id, args| {
                     let typed_value = value
                         .downcast_ref::<Ret>()
                         .or_with_context(|| format!("Failed to downcast the result of the node `{tag}`"))?;
@@ -124,10 +124,10 @@ impl<SP: SessionParameters> Replacement<SP> {
             + Send
             + Sync
             + Fn(
-                Result<&Ret, ThirdPartyAttributableError<SP>>,
+                Result<&Ret, MaybeAttributableError<ThirdPartyError<SP>>>,
                 &SP::Verifier,
                 &Args<SP>,
-            ) -> Result<Ret, ThirdPartyAttributableError<SP>>,
+            ) -> Result<Ret, MaybeAttributableError<ThirdPartyError<SP>>>,
     {
         let tag = ComputedMappingTag::new_with_full_name(
             FullName::new_with_prefix(name)
@@ -136,16 +136,14 @@ impl<SP: SessionParameters> Replacement<SP> {
         Ok(Self {
             tag: AnyTag::Mapping(MappingTag::Computed(tag)),
             kind: ReplacementEnum::ComputeMappingThirdPartyAttributable {
-                function: Arc::new(
-                    move |maybe_value: Result<Value, ThirdPartyAttributableError<SP>>, id, args| {
-                        let typed_value = maybe_value
-                            .as_ref()
-                            .map_err(Clone::clone)
-                            .and_then(|value| value.downcast_ref::<Ret>().map_err(ThirdPartyAttributableError::from));
-                        let typed_result = function(typed_value, id, args)?;
-                        Ok(Value::new(typed_result))
-                    },
-                ),
+                function: Arc::new(move |maybe_value, id, args| {
+                    let typed_value = maybe_value
+                        .as_ref()
+                        .map_err(Clone::clone)
+                        .and_then(|value| value.downcast_ref::<Ret>().map_err(MaybeAttributableError::from));
+                    let typed_result = function(typed_value, id, args)?;
+                    Ok(Value::new(typed_result))
+                }),
             },
         })
     }

--- a/ayatori/src/dev/replacements.rs
+++ b/ayatori/src/dev/replacements.rs
@@ -10,6 +10,7 @@ use crate::{
         SimpleMappingFunction, ThirdPartyAttributableError, ThirdPartyAttributableMappingFunction, UnattributableError,
         UnattributableMappingFunction, UnattributableScalarFunction, Value,
     },
+    error::TraceableResult,
     graph_representation::{AnyNode, ComputeMappingKind, GeneralizedNode, OutputNode, ShallowClone},
     traits::SessionParameters,
 };
@@ -73,12 +74,17 @@ impl<SP: SessionParameters> Replacement<SP> {
         Ret: Erasable,
         F: 'static + Send + Sync + Fn(&Ret, &Args<SP>) -> Result<Ret, UnattributableError>,
     {
-        let tag = ComputedScalarTag::new_with_full_name(FullName::new_with_prefix(name)?);
+        let tag = ComputedScalarTag::new_with_full_name(
+            FullName::new_with_prefix(name)
+                .or_with_context(|| format!("Failed to create a tag from the name `{name:?}`"))?,
+        );
         Ok(Self {
-            tag: AnyTag::Scalar(ScalarTag::Computed(tag)),
+            tag: AnyTag::Scalar(ScalarTag::Computed(tag.clone())),
             kind: ReplacementEnum::ComputeScalar {
                 function: Arc::new(move |value, args| {
-                    let typed_value = value.downcast_ref::<Ret>()?;
+                    let typed_value = value
+                        .downcast_ref::<Ret>()
+                        .or_with_context(|| format!("Failed to downcast the result of the node `{tag}`"))?;
                     let typed_result = function(typed_value, args)?;
                     Ok(Value::new(typed_result))
                 }),
@@ -92,12 +98,17 @@ impl<SP: SessionParameters> Replacement<SP> {
         Ret: Erasable,
         F: 'static + Send + Sync + Fn(&Ret, &SP::Verifier, &Args<SP>) -> Result<Ret, UnattributableError>,
     {
-        let tag = ComputedMappingTag::new_with_full_name(FullName::new_with_prefix(name)?);
+        let tag = ComputedMappingTag::new_with_full_name(
+            FullName::new_with_prefix(name)
+                .or_with_context(|| format!("Failed to create a tag from the name `{name:?}`"))?,
+        );
         Ok(Self {
-            tag: AnyTag::Mapping(MappingTag::Computed(tag)),
+            tag: AnyTag::Mapping(MappingTag::Computed(tag.clone())),
             kind: ReplacementEnum::ComputeMapping {
                 function: Arc::new(move |value: Value, id, args| {
-                    let typed_value = value.downcast_ref::<Ret>()?;
+                    let typed_value = value
+                        .downcast_ref::<Ret>()
+                        .or_with_context(|| format!("Failed to downcast the result of the node `{tag}`"))?;
                     let typed_result = function(typed_value, id, args)?;
                     Ok(Value::new(typed_result))
                 }),
@@ -118,7 +129,10 @@ impl<SP: SessionParameters> Replacement<SP> {
                 &Args<SP>,
             ) -> Result<Ret, ThirdPartyAttributableError<SP>>,
     {
-        let tag = ComputedMappingTag::new_with_full_name(FullName::new_with_prefix(name)?);
+        let tag = ComputedMappingTag::new_with_full_name(
+            FullName::new_with_prefix(name)
+                .or_with_context(|| format!("Failed to create a tag from the name `{name:?}`"))?,
+        );
         Ok(Self {
             tag: AnyTag::Mapping(MappingTag::Computed(tag)),
             kind: ReplacementEnum::ComputeMappingThirdPartyAttributable {
@@ -149,12 +163,17 @@ impl<SP: SessionParameters> Replacement<SP> {
                 &SerializeArgs<SP>,
             ) -> Result<SignedValue<SP>, RuntimeError>,
     {
-        let tag = LocalSignedTag::new_with_full_name(FullName::new_with_prefix(name)?);
+        let tag = LocalSignedTag::new_with_full_name(
+            FullName::new_with_prefix(name)
+                .or_with_context(|| format!("Failed to create a tag from the name `{name:?}`"))?,
+        );
         Ok(Self {
-            tag: AnyTag::Mapping(MappingTag::LocalSigned(tag)),
+            tag: AnyTag::Mapping(MappingTag::LocalSigned(tag.clone())),
             kind: ReplacementEnum::Message {
                 function: Arc::new(move |rng, orig_value, destination, args| {
-                    let typed_value = orig_value.downcast_ref::<SignedValue<SP>>()?;
+                    let typed_value = orig_value
+                        .downcast_ref::<SignedValue<SP>>()
+                        .or_with_context(|| format!("Failed to downcast the result of the node `{tag}`"))?;
                     let typed_result = function(rng, typed_value, destination, args)?;
                     Ok(Value::new(typed_result))
                 }),
@@ -165,7 +184,7 @@ impl<SP: SessionParameters> Replacement<SP> {
     pub(crate) fn apply(&self, node: &OutputNode<SP>) -> Result<OutputNode<SP>, RuntimeError> {
         let subnode = AnyNode::from(node.get_strong_ref())
             .find_subnode(self.tag.as_ref())
-            .ok_or_else(|| RuntimeError::new("Node not found"))?;
+            .ok_or_else(|| RuntimeError::new(format!("Failed to find subnode `{}` to replace", self.tag)))?;
         let new_subnode = match (&subnode, &self.kind) {
             (
                 AnyNode::ComputeScalar(node),
@@ -184,7 +203,10 @@ impl<SP: SessionParameters> Replacement<SP> {
                         },
                     ))
                 } else {
-                    return Err(RuntimeError::new("Invalid function type"));
+                    return Err(RuntimeError::new(format!(
+                        "Invalid function type in the subnode `{}` - expected unattributable scalar function",
+                        self.tag
+                    )));
                 };
 
                 AnyNode::from(node.get_strong_ref().mutated(|inner| {
@@ -214,7 +236,10 @@ impl<SP: SessionParameters> Replacement<SP> {
                         ));
                     ComputeMappingKind::Simple { function: new_function }
                 } else {
-                    return Err(RuntimeError::new("Invalid function type"));
+                    return Err(RuntimeError::new(format!(
+                        "Invalid function type in the subnode `{}` - expected unattributable mapping function",
+                        self.tag
+                    )));
                 };
 
                 AnyNode::from(node.get_strong_ref().mutated(|inner| {
@@ -247,7 +272,10 @@ impl<SP: SessionParameters> Replacement<SP> {
                         verification: verification.clone(),
                     }
                 } else {
-                    return Err(RuntimeError::new("Invalid function type"));
+                    return Err(RuntimeError::new(format!(
+                        "Invalid function type in the subnode `{}` - expected third party attributable mapping function",
+                        self.tag
+                    )));
                 };
 
                 AnyNode::from(node.get_strong_ref().mutated(|inner| {
@@ -275,7 +303,12 @@ impl<SP: SessionParameters> Replacement<SP> {
                     inner
                 }))
             }
-            _ => return Err(RuntimeError::new("Not supported")),
+            _ => {
+                return Err(RuntimeError::new(format!(
+                    "The type of the subnode `{}` does not match the replacement type",
+                    self.tag
+                )));
+            }
         };
         Ok(AnyNode::from(node.get_strong_ref())
             .with_replaced_subnode(&subnode, &new_subnode)

--- a/ayatori/src/dev/run_sync.rs
+++ b/ayatori/src/dev/run_sync.rs
@@ -42,10 +42,10 @@ pub fn run_sessions_sync<SP: SessionParameters, P: ExecutableProtocol<SP>>(
 
             while let Some(task) = session.make_task().or_with_context(|| "Failed to make a task".into())? {
                 let task_result = match task {
-                    Task::Compute(task) => session.add_result(task.compute()),
-                    Task::ComputeWithRng(task) => session.add_result(task.compute(rng)),
+                    Task::Compute(task) => session.add_result(task.execute()),
+                    Task::ComputeWithRng(task) => session.add_result(task.execute(rng)),
                     Task::Send(task) => {
-                        let (message, result) = task.compute();
+                        let (message, result) = task.execute();
                         if let Some(message) = message {
                             let destination = message.destination().clone();
                             messages

--- a/ayatori/src/dev/run_sync.rs
+++ b/ayatori/src/dev/run_sync.rs
@@ -3,7 +3,8 @@ use alloc::{collections::BTreeMap, format, vec::Vec};
 use signature::rand_core::CryptoRngCore;
 
 use crate::{
-    entities::{Message, MessageId, UnattributableError},
+    entities::{Message, MessageId, RuntimeError, UnattributableError},
+    error::TraceableResult,
     execution::{Session, SessionReport, SessionState, Task, TaskError},
     traits::{ExecutableProtocol, SessionParameters},
 };
@@ -32,14 +33,14 @@ pub fn run_sessions_sync<SP: SessionParameters, P: ExecutableProtocol<SP>>(
             let id = session.verifier().clone();
             for message in messages
                 .get_mut(&id)
-                .ok_or_else(|| UnattributableError::runtime(format!("{id:?} not found in the map of message queues")))?
+                .ok_or_else(|| RuntimeError::new(format!("{id:?} not found in the map of message queues")))?
                 .drain(..)
             {
                 let message_id = MessageId::random(rng);
                 session.add_message(&message_id, message);
             }
 
-            while let Some(task) = session.make_task()? {
+            while let Some(task) = session.make_task().or_with_context(|| "Failed to make a task".into())? {
                 let task_result = match task {
                     Task::Compute(task) => session.add_result(task.compute()),
                     Task::ComputeWithRng(task) => session.add_result(task.compute(rng)),
@@ -50,9 +51,7 @@ pub fn run_sessions_sync<SP: SessionParameters, P: ExecutableProtocol<SP>>(
                             messages
                                 .get_mut(&destination)
                                 .ok_or_else(|| {
-                                    UnattributableError::runtime(format!(
-                                        "{id:?} not found in the map of message queues"
-                                    ))
+                                    RuntimeError::new(format!("{id:?} not found in the map of message queues"))
                                 })?
                                 .push(message);
                         }
@@ -65,9 +64,7 @@ pub fn run_sessions_sync<SP: SessionParameters, P: ExecutableProtocol<SP>>(
                     Ok(()) => {}
                     Err(TaskError::Unattributable(error)) => return Err(error),
                     Err(TaskError::MessageAttributable(error)) => {
-                        return Err(UnattributableError::runtime(format!(
-                            "Message-attributable error: {error:?}"
-                        )));
+                        return Err(RuntimeError::new(format!("Message-attributable error: {error:?}")).into());
                     }
                 }
             }
@@ -80,9 +77,10 @@ pub fn run_sessions_sync<SP: SessionParameters, P: ExecutableProtocol<SP>>(
         }
 
         if !task_processed {
-            return Err(UnattributableError::runtime(
+            return Err(RuntimeError::new(
                 "Sessions are stuck: there are still active sessions, but no tasks are being created",
-            ));
+            )
+            .into());
         }
     }
 

--- a/ayatori/src/dev/run_sync.rs
+++ b/ayatori/src/dev/run_sync.rs
@@ -42,8 +42,8 @@ pub fn run_sessions_sync<SP: SessionParameters, P: ExecutableProtocol<SP>>(
 
             while let Some(task) = session.make_task().or_with_context(|| "Failed to make a task".into())? {
                 let task_result = match task {
-                    Task::Compute(task) => session.add_result(task.execute()),
-                    Task::ComputeWithRng(task) => session.add_result(task.execute(rng)),
+                    Task::Deterministic(task) => session.add_result(task.execute()),
+                    Task::Randomized(task) => session.add_result(task.execute(rng)),
                     Task::Send(task) => {
                         let (message, result) = task.execute();
                         if let Some(message) = message {

--- a/ayatori/src/dev/run_sync.rs
+++ b/ayatori/src/dev/run_sync.rs
@@ -5,7 +5,7 @@ use signature::rand_core::CryptoRngCore;
 use crate::{
     entities::{Message, MessageId, RuntimeError},
     error::TraceableResult,
-    execution::{Session, SessionReport, SessionState, Task, TaskError},
+    execution::{Session, SessionReport, SessionState, Task},
     traits::{ExecutableProtocol, SessionParameters},
 };
 
@@ -21,9 +21,6 @@ pub fn run_sessions_sync<SP: SessionParameters, P: ExecutableProtocol<SP>>(
         .collect::<BTreeMap<_, _>>();
     let mut reports = BTreeMap::new();
 
-    let mut finished_with_success = Vec::new();
-    let mut finished_with_stall = Vec::new();
-
     while !sessions.is_empty() {
         let mut task_processed = false;
 
@@ -31,6 +28,7 @@ pub fn run_sessions_sync<SP: SessionParameters, P: ExecutableProtocol<SP>>(
 
         for mut session in sessions_to_process {
             let id = session.verifier().clone();
+
             for message in messages
                 .get_mut(&id)
                 .ok_or_else(|| RuntimeError::new(format!("{id:?} not found in the map of message queues")))?
@@ -40,8 +38,15 @@ pub fn run_sessions_sync<SP: SessionParameters, P: ExecutableProtocol<SP>>(
                 session.add_message(&message_id, message);
             }
 
-            while let Some(task) = session.make_task().or_with_context(|| "Failed to make a task".into())? {
-                let task_result = match task {
+            loop {
+                let Some(task) = session.make_task().or_with_context(|| "Failed to make a task".into())? else {
+                    sessions.push(session);
+                    break;
+                };
+
+                task_processed = true;
+
+                let new_state = match task {
                     Task::Deterministic(task) => session.add_result(task.execute()),
                     Task::Randomized(task) => session.add_result(task.execute(rng)),
                     Task::Send(task) => {
@@ -57,46 +62,34 @@ pub fn run_sessions_sync<SP: SessionParameters, P: ExecutableProtocol<SP>>(
                         }
                         session.add_result(result)
                     }
-                };
-                task_processed = true;
+                }?;
 
-                match task_result {
-                    Ok(()) => {}
-                    Err(TaskError::Runtime(error)) => return Err(error),
-                    // TODO: record non-runtime errors per session
-                    Err(TaskError::Spurious(error)) => {
-                        return Err(RuntimeError::new(format!("Spurious error: {error:?}")));
-                    }
-                    Err(TaskError::MessageAttributable(error)) => {
+                session = match new_state {
+                    SessionState::InProgress(session) => session,
+                    SessionState::InProgressWithMessageError { error, .. } => {
                         return Err(RuntimeError::new(format!("Message-attributable error: {error:?}")));
                     }
-                }
-            }
-
-            match session.try_finalize() {
-                SessionState::InProgress(session) => sessions.push(session),
-                SessionState::ReachedOutput(success) => finished_with_success.push(success),
-                SessionState::Stalled(stalled) => finished_with_stall.push(stalled),
+                    SessionState::ReachedOutput(success) => {
+                        let report = success.finalize()?;
+                        reports.insert(id, report);
+                        break;
+                    }
+                    SessionState::Unfinishable(report) => {
+                        reports.insert(id, report);
+                        break;
+                    }
+                };
             }
         }
 
         if !task_processed {
-            return Err(RuntimeError::new(
-                "Sessions are stuck: there are still active sessions, but no tasks are being created",
-            ));
+            // That's where in production the sessions would time out and get terminated externally.
+            for session in sessions {
+                reports.insert(session.verifier().clone(), session.terminate());
+            }
+
+            break;
         }
-    }
-
-    for session in finished_with_success {
-        let id = session.as_ref().verifier().clone();
-        let report = session.finalize()?;
-        reports.insert(id.clone(), report);
-    }
-
-    for session in finished_with_stall {
-        let id = session.as_ref().verifier().clone();
-        let report = session.finalize();
-        reports.insert(id.clone(), report);
     }
 
     Ok(ExecutionResult { reports })

--- a/ayatori/src/dev/run_sync.rs
+++ b/ayatori/src/dev/run_sync.rs
@@ -3,7 +3,7 @@ use alloc::{collections::BTreeMap, format, vec::Vec};
 use signature::rand_core::CryptoRngCore;
 
 use crate::{
-    entities::{Message, MessageId, RuntimeError, UnattributableError},
+    entities::{Message, MessageId, RuntimeError},
     error::TraceableResult,
     execution::{Session, SessionReport, SessionState, Task, TaskError},
     traits::{ExecutableProtocol, SessionParameters},
@@ -13,7 +13,7 @@ use crate::{
 pub fn run_sessions_sync<SP: SessionParameters, P: ExecutableProtocol<SP>>(
     rng: &mut impl CryptoRngCore,
     sessions: Vec<Session<SP, P>>,
-) -> Result<ExecutionResult<SP, P>, UnattributableError> {
+) -> Result<ExecutionResult<SP, P>, RuntimeError> {
     let mut sessions = sessions;
     let mut messages = sessions
         .iter()
@@ -62,9 +62,13 @@ pub fn run_sessions_sync<SP: SessionParameters, P: ExecutableProtocol<SP>>(
 
                 match task_result {
                     Ok(()) => {}
-                    Err(TaskError::Unattributable(error)) => return Err(error),
+                    Err(TaskError::Runtime(error)) => return Err(error),
+                    // TODO: record non-runtime errors per session
+                    Err(TaskError::Spurious(error)) => {
+                        return Err(RuntimeError::new(format!("Spurious error: {error:?}")));
+                    }
                     Err(TaskError::MessageAttributable(error)) => {
-                        return Err(RuntimeError::new(format!("Message-attributable error: {error:?}")).into());
+                        return Err(RuntimeError::new(format!("Message-attributable error: {error:?}")));
                     }
                 }
             }
@@ -79,8 +83,7 @@ pub fn run_sessions_sync<SP: SessionParameters, P: ExecutableProtocol<SP>>(
         if !task_processed {
             return Err(RuntimeError::new(
                 "Sessions are stuck: there are still active sessions, but no tasks are being created",
-            )
-            .into());
+            ));
         }
     }
 

--- a/ayatori/src/dev/tokio.rs
+++ b/ayatori/src/dev/tokio.rs
@@ -9,9 +9,9 @@ use tokio_util::sync::CancellationToken;
 
 use super::run_sync::ExecutionResult;
 use crate::{
-    entities::{Message, MessageId, RuntimeError, UnattributableError},
+    entities::{Message, MessageId, RuntimeError},
     execution::{
-        Session, SessionReport,
+        Session, SessionError, SessionReport,
         tokio::{MessageIn, MessageOut, SessionRunner},
     },
     traits::{ExecutableProtocol, SessionParameters},
@@ -96,7 +96,7 @@ where
             CancellationToken,
             Session<SP, P>,
         ) -> Fut,
-    Fut: Send + Future<Output = Result<SessionReport<SP, P>, UnattributableError>> + 'a,
+    Fut: Send + Future<Output = Result<SessionReport<SP, P>, SessionError>> + 'a,
 {
     type Fut = Fut;
     fn call(
@@ -116,7 +116,7 @@ pub async fn run_sessions_async<SP, P, F, R>(
     rng: &mut R,
     sessions: Vec<Session<SP, P>>,
     session_runner: F,
-) -> Result<ExecutionResult<SP, P>, UnattributableError>
+) -> Result<ExecutionResult<SP, P>, SessionError>
 where
     R: 'static + CryptoRngCore + Clone + Send,
     SP: SessionParameters,
@@ -156,7 +156,7 @@ where
             let node_task = async move { session_runner.call(&mut rng, &tx, &mut rx, cancellation, session).await };
             Ok((id, tokio::spawn(node_task)))
         })
-        .collect::<Result<BTreeMap<_, _>, UnattributableError>>()?;
+        .collect::<Result<BTreeMap<_, _>, SessionError>>()?;
 
     // Drop the last copy of the dispatcher's incoming channel so that it can finish.
     drop(dispatcher_tx);

--- a/ayatori/src/dev/tokio.rs
+++ b/ayatori/src/dev/tokio.rs
@@ -11,7 +11,7 @@ use super::run_sync::ExecutionResult;
 use crate::{
     entities::{Message, MessageId, RuntimeError},
     execution::{
-        Session, SessionError, SessionReport,
+        Session, SessionReport,
         tokio::{MessageIn, MessageOut, SessionRunner},
     },
     traits::{ExecutableProtocol, SessionParameters},
@@ -96,7 +96,7 @@ where
             CancellationToken,
             Session<SP, P>,
         ) -> Fut,
-    Fut: Send + Future<Output = Result<SessionReport<SP, P>, SessionError>> + 'a,
+    Fut: Send + Future<Output = Result<SessionReport<SP, P>, RuntimeError>> + 'a,
 {
     type Fut = Fut;
     fn call(
@@ -116,7 +116,7 @@ pub async fn run_sessions_async<SP, P, F, R>(
     rng: &mut R,
     sessions: Vec<Session<SP, P>>,
     session_runner: F,
-) -> Result<ExecutionResult<SP, P>, SessionError>
+) -> Result<ExecutionResult<SP, P>, RuntimeError>
 where
     R: 'static + CryptoRngCore + Clone + Send,
     SP: SessionParameters,
@@ -156,7 +156,7 @@ where
             let node_task = async move { session_runner.call(&mut rng, &tx, &mut rx, cancellation, session).await };
             Ok((id, tokio::spawn(node_task)))
         })
-        .collect::<Result<BTreeMap<_, _>, SessionError>>()?;
+        .collect::<Result<BTreeMap<_, _>, RuntimeError>>()?;
 
     // Drop the last copy of the dispatcher's incoming channel so that it can finish.
     drop(dispatcher_tx);

--- a/ayatori/src/entities.rs
+++ b/ayatori/src/entities.rs
@@ -23,8 +23,8 @@ pub(crate) use value::Value;
 
 pub use args::{Args, DeserializeArgs, OneOrBoth, SerializeArgs};
 pub use errors::{
-    AssociatedData, RuntimeError, SenderAttributableError, SenderAttributableErrorWithReveal, SenderError,
-    SenderErrorWithReveal, SpuriousError, ThirdPartyAttributableError, ThirdPartyError, UnattributableError,
+    AssociatedData, MaybeAttributableError, RuntimeError, SenderError, SenderErrorWithReveal, SpuriousError,
+    ThirdPartyError, UnattributableError,
 };
 pub use function::EvidenceVerdict;
 pub use message::{Message, MessageId, SignedHash, SignedValue, ValueMetadata, VerificationError, VerifiedValue};

--- a/ayatori/src/entities.rs
+++ b/ayatori/src/entities.rs
@@ -7,10 +7,7 @@ mod session_id;
 mod tag;
 mod value;
 
-pub(crate) use errors::{
-    SenderAttributableErrorEnum, SenderAttributableErrorWithRevealEnum, SenderError, SenderErrorWithReveal,
-    ThirdPartyAttributableErrorEnum, ThirdPartyError,
-};
+pub(crate) use errors::StoredThirdPartyError;
 pub(crate) use function::{
     DeserializeFunction, MappingFunction, ScalarFunction, SenderAttributableMappingFunction,
     SenderAttributableVerificationFunction, SenderAttributableWithRevealMappingFunction, SerializeAndSignFunction,
@@ -26,8 +23,8 @@ pub(crate) use value::Value;
 
 pub use args::{Args, DeserializeArgs, OneOrBoth, SerializeArgs};
 pub use errors::{
-    AssociatedData, RuntimeError, SenderAttributableError, SenderAttributableErrorWithReveal, SpuriousError,
-    ThirdPartyAttributableError, UnattributableError,
+    AssociatedData, RuntimeError, SenderAttributableError, SenderAttributableErrorWithReveal, SenderError,
+    SenderErrorWithReveal, SpuriousError, ThirdPartyAttributableError, ThirdPartyError, UnattributableError,
 };
 pub use function::EvidenceVerdict;
 pub use message::{Message, MessageId, SignedHash, SignedValue, ValueMetadata, VerificationError, VerifiedValue};

--- a/ayatori/src/entities/args.rs
+++ b/ayatori/src/entities/args.rs
@@ -14,7 +14,7 @@ use super::{
     tag::FullName,
     value::{Erasable, SerdeAdapter, Value},
 };
-use crate::traits::SessionParameters;
+use crate::{error::TraceableResult, traits::SessionParameters};
 
 #[cfg(doc)]
 use crate::protocol_author_api::{
@@ -105,6 +105,7 @@ impl<SP: SessionParameters> DeserializeArgs<SP> {
     pub(crate) fn verified_value(&self) -> &VerifiedValue<SP> {
         self.value
             .downcast_ref::<VerifiedValue<SP>>()
+            // TODO: was it checked?
             .expect("the value type was already checked in the constructor")
     }
 }
@@ -150,7 +151,9 @@ impl<SP: SessionParameters> Args<SP> {
     ///
     /// Fails if `name` was not present in the argument list, or the type of the stored value is not `T`.
     pub fn get<T: Erasable>(&self, name: &str) -> Result<&T, RuntimeError> {
-        self.get_value(name)?.downcast_ref::<T>()
+        self.get_value(name)?
+            .downcast_ref::<T>()
+            .or_with_context(|| format!("Failed to downcast the value `{name}`"))
     }
 
     /// Returns the value from the storage slot that was declared as the argument for this computation
@@ -163,7 +166,12 @@ impl<SP: SessionParameters> Args<SP> {
         let value_map = self.get::<BTreeMap<SP::Verifier, Value>>(name)?;
         value_map
             .iter()
-            .map(|(id, value)| value.downcast_ref::<T>().map(|value_ref| (id, value_ref)))
+            .map(|(id, value)| {
+                value
+                    .downcast_ref::<T>()
+                    .map(|value_ref| (id, value_ref))
+                    .or_with_context(|| format!("Failed to downcast the element `{id:?}` of the mapping `{name}`"))
+            })
             .collect()
     }
 
@@ -178,12 +186,24 @@ impl<SP: SessionParameters> Args<SP> {
         name: &str,
     ) -> Result<OneOrBoth<&L, &R>, RuntimeError> {
         Ok(match self.get::<OneOrBoth<Value, Value>>(name)? {
-            OneOrBoth::Left(left) => OneOrBoth::Left(left.downcast_ref::<L>()?),
-            OneOrBoth::Right(right) => OneOrBoth::Right(right.downcast_ref::<R>()?),
-            OneOrBoth::Both { left, right } => OneOrBoth::Both {
-                left: left.downcast_ref::<L>()?,
-                right: right.downcast_ref::<R>()?,
-            },
+            OneOrBoth::Left(left) => OneOrBoth::Left(
+                left.downcast_ref::<L>()
+                    .or_with_context(|| format!("Failed to downcast the left variant of the merged value `{name}`"))?,
+            ),
+            OneOrBoth::Right(right) => OneOrBoth::Right(
+                right
+                    .downcast_ref::<R>()
+                    .or_with_context(|| format!("Failed to downcast the right variant of the merged value `{name}`"))?,
+            ),
+            OneOrBoth::Both { left, right } => {
+                let left = left
+                    .downcast_ref::<L>()
+                    .or_with_context(|| format!("Failed to downcast the left variant of the merged value `{name}`"))?;
+                let right = right
+                    .downcast_ref::<R>()
+                    .or_with_context(|| format!("Failed to downcast the right variant of the merged value `{name}`"))?;
+                OneOrBoth::Both { left, right }
+            }
         })
     }
 }

--- a/ayatori/src/entities/args.rs
+++ b/ayatori/src/entities/args.rs
@@ -102,11 +102,10 @@ impl<SP: SessionParameters> DeserializeArgs<SP> {
         &self.serde_adapter
     }
 
-    pub(crate) fn verified_value(&self) -> &VerifiedValue<SP> {
+    pub(crate) fn verified_value(&self) -> Result<&VerifiedValue<SP>, RuntimeError> {
         self.value
             .downcast_ref::<VerifiedValue<SP>>()
-            // TODO: was it checked?
-            .expect("the value type was already checked in the constructor")
+            .or_with_context(|| "Failed to downcast a `VerifiedValue`".into())
     }
 }
 

--- a/ayatori/src/entities/errors.rs
+++ b/ayatori/src/entities/errors.rs
@@ -1,5 +1,8 @@
 use alloc::{format, string::String};
-use core::{fmt::Debug, marker::PhantomData};
+use core::{
+    fmt::{Debug, Display},
+    marker::PhantomData,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -29,6 +32,8 @@ impl SpuriousError {
     }
 }
 
+impl core::error::Error for SpuriousError {}
+
 /// An error where some check that couldn't be ensured via the type system failed ar runtime.
 ///
 /// This error indicates that there is either a problem with the environment, or there is a bug in the code.
@@ -57,6 +62,8 @@ impl Traceable for RuntimeError {
         Self(self.0.with_context(context))
     }
 }
+
+impl core::error::Error for RuntimeError {}
 
 /// An error during computation that is not attributable to a specific party.
 #[derive(displaydoc::Display, Debug, Clone)]
@@ -94,6 +101,8 @@ impl UnattributableError {
     }
 }
 
+impl core::error::Error for UnattributableError {}
+
 /// An error occuring during a computation that may be attributable to a specific party.
 #[derive(displaydoc::Display, Debug, Clone)]
 pub enum MaybeAttributableError<E> {
@@ -118,6 +127,8 @@ pub struct SenderError {
     description: String,
 }
 
+impl<E: Debug + Display> core::error::Error for MaybeAttributableError<E> {}
+
 impl SenderError {
     /// Creates a new error with the given description.
     pub fn new(description: impl Into<String>) -> Self {
@@ -132,6 +143,8 @@ impl From<SenderError> for MaybeAttributableError<SenderError> {
         Self::Attributable(source)
     }
 }
+
+impl core::error::Error for SenderError {}
 
 /// Additional data (not calculated in the nodes leading to the error) to be attached to the evidence.
 #[derive_where::derive_where(Debug, Clone, Serialize, Deserialize)]
@@ -196,6 +209,8 @@ impl<SP: SessionParameters> From<SenderErrorWithReveal<SP>> for MaybeAttributabl
     }
 }
 
+impl<SP: SessionParameters> core::error::Error for SenderErrorWithReveal<SP> {}
+
 /// An error attributable to a third party (not the one that sent the triggering message), with associated data.
 #[derive(displaydoc::Display)]
 #[derive_where::derive_where(Debug, Clone, Serialize, Deserialize)]
@@ -243,6 +258,8 @@ impl<SP: SessionParameters> From<ThirdPartyError<SP>> for MaybeAttributableError
         Self::Attributable(source)
     }
 }
+
+impl<SP: SessionParameters> core::error::Error for ThirdPartyError<SP> {}
 
 /// Guilty party is stored separately in [`Evidence`], this structure represents the rest of [`ThirdPartyError`].
 #[derive(displaydoc::Display)]

--- a/ayatori/src/entities/errors.rs
+++ b/ayatori/src/entities/errors.rs
@@ -4,7 +4,10 @@ use core::{fmt::Debug, marker::PhantomData};
 use serde::{Deserialize, Serialize};
 
 use super::value::SerializedValue;
-use crate::traits::{SessionParameters, WireFormat};
+use crate::{
+    error::{Traceable, TracedError},
+    traits::{SessionParameters, WireFormat},
+};
 
 /// A randomly occuring error that is not a result of a misuse of the API, or malicious actions of other parties.
 ///
@@ -32,17 +35,26 @@ impl SpuriousError {
 /// The protocol should not be restarted until the problem is fixed.
 #[derive(displaydoc::Display, Debug, Clone)]
 #[displaydoc("Runtime error: {0}")]
-pub struct RuntimeError(String);
+pub struct RuntimeError(TracedError);
 
 impl RuntimeError {
     /// Creates a new error with the given description.
+    #[track_caller]
     pub fn new(description: impl Into<String>) -> Self {
-        Self(description.into())
+        Self(TracedError::new(description))
     }
 
     /// Indicates a runtime error that is unreachable in tests.
-    pub fn expect(description: impl Into<String>) -> Self {
-        Self(description.into())
+    #[track_caller]
+    pub(crate) fn expect(description: impl Into<String>) -> Self {
+        Self(TracedError::new(description))
+    }
+}
+
+impl Traceable for RuntimeError {
+    #[track_caller]
+    fn with_context(self, context: impl Into<String>) -> Self {
+        Self(self.0.with_context(context))
     }
 }
 
@@ -63,6 +75,12 @@ impl From<RuntimeError> for UnattributableError {
     }
 }
 
+impl From<SpuriousError> for UnattributableError {
+    fn from(source: SpuriousError) -> Self {
+        Self::Spurious(source)
+    }
+}
+
 impl UnattributableError {
     /// Returns the [`UnattributableError::Spurious`] variant.
     pub fn spurious(description: impl Into<String>) -> Self {
@@ -70,6 +88,7 @@ impl UnattributableError {
     }
 
     /// Returns the [`UnattributableError::Runtime`] variant.
+    #[track_caller]
     pub fn runtime(description: impl Into<String>) -> Self {
         Self::Runtime(RuntimeError::new(description))
     }
@@ -103,14 +122,15 @@ impl SenderAttributableError {
     /// Returns the [`UnattributableError::Spurious`] variant.
     pub fn spurious(description: impl Into<String>) -> Self {
         Self(SenderAttributableErrorEnum::Unattributable(
-            UnattributableError::spurious(description),
+            SpuriousError::new(description).into(),
         ))
     }
 
     /// Returns the [`UnattributableError::Runtime`] variant.
+    #[track_caller]
     pub fn runtime(description: impl Into<String>) -> Self {
         Self(SenderAttributableErrorEnum::Unattributable(
-            UnattributableError::runtime(description),
+            RuntimeError::new(description).into(),
         ))
     }
 
@@ -183,14 +203,15 @@ impl<SP: SessionParameters> SenderAttributableErrorWithReveal<SP> {
     /// Returns the [`UnattributableError::Spurious`] variant.
     pub fn spurious(description: impl Into<String>) -> Self {
         Self(SenderAttributableErrorWithRevealEnum::Unattributable(
-            UnattributableError::spurious(description),
+            SpuriousError::new(description).into(),
         ))
     }
 
     /// Returns the [`UnattributableError::Runtime`] variant.
+    #[track_caller]
     pub fn runtime(description: impl Into<String>) -> Self {
         Self(SenderAttributableErrorWithRevealEnum::Unattributable(
-            UnattributableError::runtime(description),
+            RuntimeError::new(description).into(),
         ))
     }
 
@@ -246,14 +267,15 @@ impl<SP: SessionParameters> ThirdPartyAttributableError<SP> {
     /// Returns the [`UnattributableError::Spurious`] variant.
     pub fn spurious(description: impl Into<String>) -> Self {
         Self(ThirdPartyAttributableErrorEnum::Unattributable(
-            UnattributableError::spurious(description),
+            SpuriousError::new(description).into(),
         ))
     }
 
     /// Returns the [`UnattributableError::Runtime`] variant.
+    #[track_caller]
     pub fn runtime(description: impl Into<String>) -> Self {
         Self(ThirdPartyAttributableErrorEnum::Unattributable(
-            UnattributableError::runtime(description),
+            RuntimeError::new(description).into(),
         ))
     }
 

--- a/ayatori/src/entities/errors.rs
+++ b/ayatori/src/entities/errors.rs
@@ -94,6 +94,32 @@ impl UnattributableError {
     }
 }
 
+/// An error occuring during a computation that may be attributable to a specific party.
+#[derive(displaydoc::Display, Debug, Clone)]
+pub enum MaybeAttributableError<E> {
+    /// An environment error or a bug. See [`RuntimeError`].
+    #[displaydoc("{0}")]
+    Runtime(RuntimeError),
+    /// A random spurious error (not attributable). See [`SpuriousError`].
+    #[displaydoc("{0}")]
+    Spurious(SpuriousError),
+    /// The attributable variant. See the documentation for the specific type.
+    #[displaydoc("{0}")]
+    Attributable(E),
+}
+
+impl<E> From<RuntimeError> for MaybeAttributableError<E> {
+    fn from(source: RuntimeError) -> Self {
+        Self::Runtime(source)
+    }
+}
+
+impl<E> From<SpuriousError> for MaybeAttributableError<E> {
+    fn from(source: SpuriousError) -> Self {
+        Self::Spurious(source)
+    }
+}
+
 /// An error attributable to the party with the element's ID.
 #[derive(displaydoc::Display, Debug, Clone, Serialize, Deserialize)]
 #[displaydoc("Sender error: {description}")]
@@ -110,33 +136,7 @@ impl SenderError {
     }
 }
 
-/// An error during a mapping element computation that may be attributable to the party with the element's ID.
-#[derive(displaydoc::Display, Debug, Clone)]
-pub enum SenderAttributableError {
-    /// See [`RuntimeError`].
-    #[displaydoc("{0}")]
-    Runtime(RuntimeError),
-    /// See [`SpuriousError`].
-    #[displaydoc("{0}")]
-    Spurious(SpuriousError),
-    /// See [`SenderError`].
-    #[displaydoc("{0}")]
-    Attributable(SenderError),
-}
-
-impl From<RuntimeError> for SenderAttributableError {
-    fn from(source: RuntimeError) -> Self {
-        Self::Runtime(source)
-    }
-}
-
-impl From<SpuriousError> for SenderAttributableError {
-    fn from(source: SpuriousError) -> Self {
-        Self::Spurious(source)
-    }
-}
-
-impl From<SenderError> for SenderAttributableError {
+impl From<SenderError> for MaybeAttributableError<SenderError> {
     fn from(source: SenderError) -> Self {
         Self::Attributable(source)
     }
@@ -199,41 +199,13 @@ impl<SP: SessionParameters> SenderErrorWithReveal<SP> {
     }
 }
 
-/// An error during a mapping element computation that is attributable to the party with the element's ID,
-/// and needs additional data to be revealed and stored in the evidence.
-#[derive(displaydoc::Display)]
-#[derive_where::derive_where(Debug, Clone)]
-pub enum SenderAttributableErrorWithReveal<SP: SessionParameters> {
-    /// See [`RuntimeError`].
-    #[displaydoc("{0}")]
-    Runtime(RuntimeError),
-    /// See [`SpuriousError`].
-    #[displaydoc("{0}")]
-    Spurious(SpuriousError),
-    /// See [`SenderErrorWithReveal`].
-    #[displaydoc("{0}")]
-    Attributable(SenderErrorWithReveal<SP>),
-}
-
-impl<SP: SessionParameters> From<RuntimeError> for SenderAttributableErrorWithReveal<SP> {
-    fn from(source: RuntimeError) -> Self {
-        Self::Runtime(source)
-    }
-}
-
-impl<SP: SessionParameters> From<SpuriousError> for SenderAttributableErrorWithReveal<SP> {
-    fn from(source: SpuriousError) -> Self {
-        Self::Spurious(source)
-    }
-}
-
-impl<SP: SessionParameters> From<SenderErrorWithReveal<SP>> for SenderAttributableErrorWithReveal<SP> {
+impl<SP: SessionParameters> From<SenderErrorWithReveal<SP>> for MaybeAttributableError<SenderErrorWithReveal<SP>> {
     fn from(source: SenderErrorWithReveal<SP>) -> Self {
         Self::Attributable(source)
     }
 }
 
-/// An error attributable to a third party (not the one that sent the triggering message)   , with associated data.
+/// An error attributable to a third party (not the one that sent the triggering message), with associated data.
 #[derive(displaydoc::Display)]
 #[derive_where::derive_where(Debug, Clone, Serialize, Deserialize)]
 #[displaydoc("Third party attributable error: {description}")]
@@ -275,35 +247,7 @@ impl<SP: SessionParameters> ThirdPartyError<SP> {
     }
 }
 
-/// An error during a mapping element computation that is attributable to a party with the ID
-/// different from that of the element's.
-#[derive(displaydoc::Display)]
-#[derive_where::derive_where(Debug, Clone)]
-pub enum ThirdPartyAttributableError<SP: SessionParameters> {
-    /// See [`RuntimeError`].
-    #[displaydoc("{0}")]
-    Runtime(RuntimeError),
-    /// See [`SpuriousError`].
-    #[displaydoc("{0}")]
-    Spurious(SpuriousError),
-    /// See [`ThirdPartyError`].
-    #[displaydoc("{0}")]
-    Attributable(ThirdPartyError<SP>),
-}
-
-impl<SP: SessionParameters> From<RuntimeError> for ThirdPartyAttributableError<SP> {
-    fn from(source: RuntimeError) -> Self {
-        Self::Runtime(source)
-    }
-}
-
-impl<SP: SessionParameters> From<SpuriousError> for ThirdPartyAttributableError<SP> {
-    fn from(source: SpuriousError) -> Self {
-        Self::Spurious(source)
-    }
-}
-
-impl<SP: SessionParameters> From<ThirdPartyError<SP>> for ThirdPartyAttributableError<SP> {
+impl<SP: SessionParameters> From<ThirdPartyError<SP>> for MaybeAttributableError<ThirdPartyError<SP>> {
     fn from(source: ThirdPartyError<SP>) -> Self {
         Self::Attributable(source)
     }

--- a/ayatori/src/entities/errors.rs
+++ b/ayatori/src/entities/errors.rs
@@ -107,31 +107,29 @@ pub struct SenderAttributableError(pub(crate) SenderAttributableErrorEnum);
 #[derive(displaydoc::Display, Debug, Clone)]
 pub(crate) enum SenderAttributableErrorEnum {
     #[displaydoc("{0}")]
-    Unattributable(UnattributableError),
+    Runtime(RuntimeError),
+    #[displaydoc("{0}")]
+    Spurious(SpuriousError),
     #[displaydoc("{0}")]
     Attributable(SenderError),
 }
 
 impl From<RuntimeError> for SenderAttributableError {
     fn from(source: RuntimeError) -> Self {
-        Self(SenderAttributableErrorEnum::Unattributable(source.into()))
+        Self(SenderAttributableErrorEnum::Runtime(source))
     }
 }
 
 impl SenderAttributableError {
     /// Returns the [`UnattributableError::Spurious`] variant.
     pub fn spurious(description: impl Into<String>) -> Self {
-        Self(SenderAttributableErrorEnum::Unattributable(
-            SpuriousError::new(description).into(),
-        ))
+        Self(SenderAttributableErrorEnum::Spurious(SpuriousError::new(description)))
     }
 
     /// Returns the [`UnattributableError::Runtime`] variant.
     #[track_caller]
     pub fn runtime(description: impl Into<String>) -> Self {
-        Self(SenderAttributableErrorEnum::Unattributable(
-            RuntimeError::new(description).into(),
-        ))
+        Self(SenderAttributableErrorEnum::Runtime(RuntimeError::new(description)))
     }
 
     /// Creates a new error with the given description.
@@ -188,31 +186,33 @@ pub struct SenderAttributableErrorWithReveal<SP: SessionParameters>(
 #[derive_where::derive_where(Debug, Clone)]
 pub(crate) enum SenderAttributableErrorWithRevealEnum<SP: SessionParameters> {
     #[displaydoc("{0}")]
-    Unattributable(UnattributableError),
+    Runtime(RuntimeError),
+    #[displaydoc("{0}")]
+    Spurious(SpuriousError),
     #[displaydoc("{0}")]
     Attributable(SenderErrorWithReveal<SP>),
 }
 
 impl<SP: SessionParameters> From<RuntimeError> for SenderAttributableErrorWithReveal<SP> {
     fn from(source: RuntimeError) -> Self {
-        Self(SenderAttributableErrorWithRevealEnum::Unattributable(source.into()))
+        Self(SenderAttributableErrorWithRevealEnum::Runtime(source))
     }
 }
 
 impl<SP: SessionParameters> SenderAttributableErrorWithReveal<SP> {
     /// Returns the [`UnattributableError::Spurious`] variant.
     pub fn spurious(description: impl Into<String>) -> Self {
-        Self(SenderAttributableErrorWithRevealEnum::Unattributable(
-            SpuriousError::new(description).into(),
-        ))
+        Self(SenderAttributableErrorWithRevealEnum::Spurious(SpuriousError::new(
+            description,
+        )))
     }
 
     /// Returns the [`UnattributableError::Runtime`] variant.
     #[track_caller]
     pub fn runtime(description: impl Into<String>) -> Self {
-        Self(SenderAttributableErrorWithRevealEnum::Unattributable(
-            RuntimeError::new(description).into(),
-        ))
+        Self(SenderAttributableErrorWithRevealEnum::Runtime(RuntimeError::new(
+            description,
+        )))
     }
 
     /// Creates a new error with the given description and an associated value (revealed data).
@@ -249,7 +249,9 @@ pub struct ThirdPartyAttributableError<SP: SessionParameters>(pub(crate) ThirdPa
 #[derive_where::derive_where(Debug, Clone)]
 pub(crate) enum ThirdPartyAttributableErrorEnum<SP: SessionParameters> {
     #[displaydoc("{0}")]
-    Unattributable(UnattributableError),
+    Runtime(RuntimeError),
+    #[displaydoc("{0}")]
+    Spurious(SpuriousError),
     #[displaydoc("{error}")]
     Attributable {
         guilty_party: SP::Verifier,
@@ -259,24 +261,22 @@ pub(crate) enum ThirdPartyAttributableErrorEnum<SP: SessionParameters> {
 
 impl<SP: SessionParameters> From<RuntimeError> for ThirdPartyAttributableError<SP> {
     fn from(source: RuntimeError) -> Self {
-        Self(ThirdPartyAttributableErrorEnum::Unattributable(source.into()))
+        Self(ThirdPartyAttributableErrorEnum::Runtime(source))
     }
 }
 
 impl<SP: SessionParameters> ThirdPartyAttributableError<SP> {
     /// Returns the [`UnattributableError::Spurious`] variant.
     pub fn spurious(description: impl Into<String>) -> Self {
-        Self(ThirdPartyAttributableErrorEnum::Unattributable(
-            SpuriousError::new(description).into(),
-        ))
+        Self(ThirdPartyAttributableErrorEnum::Spurious(SpuriousError::new(
+            description,
+        )))
     }
 
     /// Returns the [`UnattributableError::Runtime`] variant.
     #[track_caller]
     pub fn runtime(description: impl Into<String>) -> Self {
-        Self(ThirdPartyAttributableErrorEnum::Unattributable(
-            RuntimeError::new(description).into(),
-        ))
+        Self(ThirdPartyAttributableErrorEnum::Runtime(RuntimeError::new(description)))
     }
 
     /// Creates a new error with the given description and an associated value (revealed data).

--- a/ayatori/src/entities/errors.rs
+++ b/ayatori/src/entities/errors.rs
@@ -100,9 +100,6 @@ pub enum MaybeAttributableError<E> {
     /// An environment error or a bug. See [`RuntimeError`].
     #[displaydoc("{0}")]
     Runtime(RuntimeError),
-    /// A random spurious error (not attributable). See [`SpuriousError`].
-    #[displaydoc("{0}")]
-    Spurious(SpuriousError),
     /// The attributable variant. See the documentation for the specific type.
     #[displaydoc("{0}")]
     Attributable(E),
@@ -111,12 +108,6 @@ pub enum MaybeAttributableError<E> {
 impl<E> From<RuntimeError> for MaybeAttributableError<E> {
     fn from(source: RuntimeError) -> Self {
         Self::Runtime(source)
-    }
-}
-
-impl<E> From<SpuriousError> for MaybeAttributableError<E> {
-    fn from(source: SpuriousError) -> Self {
-        Self::Spurious(source)
     }
 }
 

--- a/ayatori/src/entities/errors.rs
+++ b/ayatori/src/entities/errors.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::value::SerializedValue;
 use crate::{
-    error::{Traceable, TracedError},
+    error::{Traceable, TraceableResult, TracedError},
     traits::{SessionParameters, WireFormat},
 };
 
@@ -94,49 +94,51 @@ impl UnattributableError {
     }
 }
 
+/// An error attributable to the party with the element's ID.
 #[derive(displaydoc::Display, Debug, Clone, Serialize, Deserialize)]
 #[displaydoc("Sender error: {description}")]
-pub(crate) struct SenderError {
-    pub(crate) description: String,
+pub struct SenderError {
+    description: String,
 }
 
-/// An error during a mapping element computation that is attributable to the party with the element's ID.
-#[derive(displaydoc::Display, Debug, Clone)]
-pub struct SenderAttributableError(pub(crate) SenderAttributableErrorEnum);
+impl SenderError {
+    /// Creates a new error with the given description.
+    pub fn new(description: impl Into<String>) -> Self {
+        Self {
+            description: description.into(),
+        }
+    }
+}
 
+/// An error during a mapping element computation that may be attributable to the party with the element's ID.
 #[derive(displaydoc::Display, Debug, Clone)]
-pub(crate) enum SenderAttributableErrorEnum {
+pub enum SenderAttributableError {
+    /// See [`RuntimeError`].
     #[displaydoc("{0}")]
     Runtime(RuntimeError),
+    /// See [`SpuriousError`].
     #[displaydoc("{0}")]
     Spurious(SpuriousError),
+    /// See [`SenderError`].
     #[displaydoc("{0}")]
     Attributable(SenderError),
 }
 
 impl From<RuntimeError> for SenderAttributableError {
     fn from(source: RuntimeError) -> Self {
-        Self(SenderAttributableErrorEnum::Runtime(source))
+        Self::Runtime(source)
     }
 }
 
-impl SenderAttributableError {
-    /// Returns the [`UnattributableError::Spurious`] variant.
-    pub fn spurious(description: impl Into<String>) -> Self {
-        Self(SenderAttributableErrorEnum::Spurious(SpuriousError::new(description)))
+impl From<SpuriousError> for SenderAttributableError {
+    fn from(source: SpuriousError) -> Self {
+        Self::Spurious(source)
     }
+}
 
-    /// Returns the [`UnattributableError::Runtime`] variant.
-    #[track_caller]
-    pub fn runtime(description: impl Into<String>) -> Self {
-        Self(SenderAttributableErrorEnum::Runtime(RuntimeError::new(description)))
-    }
-
-    /// Creates a new error with the given description.
-    pub fn new(description: impl Into<String>) -> Self {
-        Self(SenderAttributableErrorEnum::Attributable(SenderError {
-            description: description.into(),
-        }))
+impl From<SenderError> for SenderAttributableError {
+    fn from(source: SenderError) -> Self {
+        Self::Attributable(source)
     }
 }
 
@@ -165,136 +167,159 @@ impl<SP: SessionParameters> AssociatedData<SP> {
     }
 }
 
+/// An error attributable to the party with the element's ID, with associated data.
 #[derive(displaydoc::Display)]
 #[derive_where::derive_where(Debug, Clone, Serialize, Deserialize)]
 #[displaydoc("Sender error (with secret reveal): {description}")]
-pub(crate) struct SenderErrorWithReveal<SP: SessionParameters> {
-    pub(crate) description: String,
-    pub(crate) associated_data: AssociatedData<SP>,
+pub struct SenderErrorWithReveal<SP: SessionParameters> {
+    description: String,
+    associated_data: AssociatedData<SP>,
+}
+
+impl<SP: SessionParameters> SenderErrorWithReveal<SP> {
+    /// Creates a new error with the given description and an associated value (revealed data).
+    pub fn new<T: Serialize + for<'de> Deserialize<'de>>(
+        description: impl Into<String>,
+        associated_value: T,
+    ) -> Result<Self, RuntimeError> {
+        let associated_data = match AssociatedData::new(associated_value) {
+            Ok(data) => data,
+            Err(error) => {
+                return Err(error).or_with_context(|| "Failed to create associated data for a sender error".into());
+            }
+        };
+        Ok(Self {
+            description: description.into(),
+            associated_data,
+        })
+    }
+
+    pub(crate) fn associated_data(&self) -> &AssociatedData<SP> {
+        &self.associated_data
+    }
 }
 
 /// An error during a mapping element computation that is attributable to the party with the element's ID,
 /// and needs additional data to be revealed and stored in the evidence.
 #[derive(displaydoc::Display)]
 #[derive_where::derive_where(Debug, Clone)]
-#[displaydoc("{0}")]
-pub struct SenderAttributableErrorWithReveal<SP: SessionParameters>(
-    pub(crate) SenderAttributableErrorWithRevealEnum<SP>,
-);
-
-#[derive(displaydoc::Display)]
-#[derive_where::derive_where(Debug, Clone)]
-pub(crate) enum SenderAttributableErrorWithRevealEnum<SP: SessionParameters> {
+pub enum SenderAttributableErrorWithReveal<SP: SessionParameters> {
+    /// See [`RuntimeError`].
     #[displaydoc("{0}")]
     Runtime(RuntimeError),
+    /// See [`SpuriousError`].
     #[displaydoc("{0}")]
     Spurious(SpuriousError),
+    /// See [`SenderErrorWithReveal`].
     #[displaydoc("{0}")]
     Attributable(SenderErrorWithReveal<SP>),
 }
 
 impl<SP: SessionParameters> From<RuntimeError> for SenderAttributableErrorWithReveal<SP> {
     fn from(source: RuntimeError) -> Self {
-        Self(SenderAttributableErrorWithRevealEnum::Runtime(source))
+        Self::Runtime(source)
     }
 }
 
-impl<SP: SessionParameters> SenderAttributableErrorWithReveal<SP> {
-    /// Returns the [`UnattributableError::Spurious`] variant.
-    pub fn spurious(description: impl Into<String>) -> Self {
-        Self(SenderAttributableErrorWithRevealEnum::Spurious(SpuriousError::new(
-            description,
-        )))
-    }
-
-    /// Returns the [`UnattributableError::Runtime`] variant.
-    #[track_caller]
-    pub fn runtime(description: impl Into<String>) -> Self {
-        Self(SenderAttributableErrorWithRevealEnum::Runtime(RuntimeError::new(
-            description,
-        )))
-    }
-
-    /// Creates a new error with the given description and an associated value (revealed data).
-    pub fn new<T: Serialize + for<'de> Deserialize<'de>>(description: impl Into<String>, associated_value: T) -> Self {
-        let associated_data = match AssociatedData::new(associated_value) {
-            Ok(data) => data,
-            Err(error) => return Self::from(error),
-        };
-        Self(SenderAttributableErrorWithRevealEnum::Attributable(
-            SenderErrorWithReveal {
-                description: description.into(),
-                associated_data,
-            },
-        ))
+impl<SP: SessionParameters> From<SpuriousError> for SenderAttributableErrorWithReveal<SP> {
+    fn from(source: SpuriousError) -> Self {
+        Self::Spurious(source)
     }
 }
 
+impl<SP: SessionParameters> From<SenderErrorWithReveal<SP>> for SenderAttributableErrorWithReveal<SP> {
+    fn from(source: SenderErrorWithReveal<SP>) -> Self {
+        Self::Attributable(source)
+    }
+}
+
+/// An error attributable to a third party (not the one that sent the triggering message)   , with associated data.
 #[derive(displaydoc::Display)]
 #[derive_where::derive_where(Debug, Clone, Serialize, Deserialize)]
 #[displaydoc("Third party attributable error: {description}")]
-pub(crate) struct ThirdPartyError<SP: SessionParameters> {
-    pub(crate) description: String,
-    pub(crate) associated_data: AssociatedData<SP>,
+pub struct ThirdPartyError<SP: SessionParameters> {
+    guilty_party: SP::Verifier,
+    description: String,
+    associated_data: AssociatedData<SP>,
+}
+
+impl<SP: SessionParameters> ThirdPartyError<SP> {
+    /// Creates a new error with the given description and an associated value (revealed data).
+    pub fn new<T: Serialize + for<'de> Deserialize<'de>>(
+        description: impl Into<String>,
+        guilty_party: &SP::Verifier,
+        associated_value: T,
+    ) -> Result<Self, RuntimeError> {
+        let associated_data = match AssociatedData::new(associated_value) {
+            Ok(data) => data,
+            Err(error) => {
+                return Err(error)
+                    .or_with_context(|| "Failed to create associated data for a third-party error".into());
+            }
+        };
+        Ok(Self {
+            guilty_party: guilty_party.clone(),
+            description: description.into(),
+            associated_data,
+        })
+    }
+
+    pub(crate) fn unpack(self) -> (SP::Verifier, StoredThirdPartyError<SP>) {
+        (
+            self.guilty_party,
+            StoredThirdPartyError {
+                description: self.description,
+                associated_data: self.associated_data,
+            },
+        )
+    }
 }
 
 /// An error during a mapping element computation that is attributable to a party with the ID
 /// different from that of the element's.
 #[derive(displaydoc::Display)]
 #[derive_where::derive_where(Debug, Clone)]
-#[displaydoc("{0}")]
-pub struct ThirdPartyAttributableError<SP: SessionParameters>(pub(crate) ThirdPartyAttributableErrorEnum<SP>);
-
-#[derive(displaydoc::Display)]
-#[derive_where::derive_where(Debug, Clone)]
-pub(crate) enum ThirdPartyAttributableErrorEnum<SP: SessionParameters> {
+pub enum ThirdPartyAttributableError<SP: SessionParameters> {
+    /// See [`RuntimeError`].
     #[displaydoc("{0}")]
     Runtime(RuntimeError),
+    /// See [`SpuriousError`].
     #[displaydoc("{0}")]
     Spurious(SpuriousError),
-    #[displaydoc("{error}")]
-    Attributable {
-        guilty_party: SP::Verifier,
-        error: ThirdPartyError<SP>,
-    },
+    /// See [`ThirdPartyError`].
+    #[displaydoc("{0}")]
+    Attributable(ThirdPartyError<SP>),
 }
 
 impl<SP: SessionParameters> From<RuntimeError> for ThirdPartyAttributableError<SP> {
     fn from(source: RuntimeError) -> Self {
-        Self(ThirdPartyAttributableErrorEnum::Runtime(source))
+        Self::Runtime(source)
     }
 }
 
-impl<SP: SessionParameters> ThirdPartyAttributableError<SP> {
-    /// Returns the [`UnattributableError::Spurious`] variant.
-    pub fn spurious(description: impl Into<String>) -> Self {
-        Self(ThirdPartyAttributableErrorEnum::Spurious(SpuriousError::new(
-            description,
-        )))
+impl<SP: SessionParameters> From<SpuriousError> for ThirdPartyAttributableError<SP> {
+    fn from(source: SpuriousError) -> Self {
+        Self::Spurious(source)
     }
+}
 
-    /// Returns the [`UnattributableError::Runtime`] variant.
-    #[track_caller]
-    pub fn runtime(description: impl Into<String>) -> Self {
-        Self(ThirdPartyAttributableErrorEnum::Runtime(RuntimeError::new(description)))
+impl<SP: SessionParameters> From<ThirdPartyError<SP>> for ThirdPartyAttributableError<SP> {
+    fn from(source: ThirdPartyError<SP>) -> Self {
+        Self::Attributable(source)
     }
+}
 
-    /// Creates a new error with the given description and an associated value (revealed data).
-    pub fn new<T: Serialize + for<'de> Deserialize<'de>>(
-        description: impl Into<String>,
-        guilty_party: &SP::Verifier,
-        associated_value: T,
-    ) -> Self {
-        let associated_data = match AssociatedData::new(associated_value) {
-            Ok(data) => data,
-            Err(error) => return Self::from(error),
-        };
-        Self(ThirdPartyAttributableErrorEnum::Attributable {
-            guilty_party: guilty_party.clone(),
-            error: ThirdPartyError {
-                description: description.into(),
-                associated_data,
-            },
-        })
+/// Guilty party is stored separately in [`Evidence`], this structure represents the rest of [`ThirdPartyError`].
+#[derive(displaydoc::Display)]
+#[derive_where::derive_where(Debug, Clone, Serialize, Deserialize)]
+#[displaydoc("Third party attributable error: {description}")]
+pub(crate) struct StoredThirdPartyError<SP: SessionParameters> {
+    description: String,
+    associated_data: AssociatedData<SP>,
+}
+
+impl<SP: SessionParameters> StoredThirdPartyError<SP> {
+    pub(crate) fn associated_data(&self) -> &AssociatedData<SP> {
+        &self.associated_data
     }
 }

--- a/ayatori/src/entities/errors.rs
+++ b/ayatori/src/entities/errors.rs
@@ -48,12 +48,6 @@ impl RuntimeError {
     pub fn new(description: impl Into<String>) -> Self {
         Self(TracedError::new(description))
     }
-
-    /// Indicates a runtime error that is unreachable in tests.
-    #[track_caller]
-    pub(crate) fn expect(description: impl Into<String>) -> Self {
-        Self(TracedError::new(description))
-    }
 }
 
 impl Traceable for RuntimeError {

--- a/ayatori/src/entities/function.rs
+++ b/ayatori/src/entities/function.rs
@@ -9,8 +9,8 @@ use signature::rand_core::CryptoRngCore;
 use super::{
     args::{Args, DeserializeArgs, SerializeArgs},
     errors::{
-        AssociatedData, RuntimeError, SenderAttributableError, SenderAttributableErrorWithReveal,
-        ThirdPartyAttributableError, UnattributableError,
+        AssociatedData, MaybeAttributableError, RuntimeError, SenderError, SenderErrorWithReveal, ThirdPartyError,
+        UnattributableError,
     },
     session_id::SessionId,
     value::{Erasable, Value},
@@ -144,17 +144,17 @@ define_typed_function_type!(
 
 define_typed_function_type!(
     SenderAttributableMappingFunction<SP>,
-    (id: &SP::Verifier, args: &Args<SP>) -> SenderAttributableError
+    (id: &SP::Verifier, args: &Args<SP>) -> MaybeAttributableError<SenderError>
 );
 
 define_typed_function_type!(
     SenderAttributableWithRevealMappingFunction<SP>,
-    (id: &SP::Verifier, args: &Args<SP>) -> SenderAttributableErrorWithReveal<SP>
+    (id: &SP::Verifier, args: &Args<SP>) -> MaybeAttributableError<SenderErrorWithReveal<SP>>
 );
 
 define_typed_function_type!(
     ThirdPartyAttributableMappingFunction<SP>,
-    (id: &SP::Verifier, args: &Args<SP>) -> ThirdPartyAttributableError<SP>
+    (id: &SP::Verifier, args: &Args<SP>) -> MaybeAttributableError<ThirdPartyError<SP>>
 );
 
 define_erased_function_type!(
@@ -176,7 +176,7 @@ define_erased_function_type!(
 
 define_erased_function_type!(
     DeserializeFunction<SP>,
-    (args: &DeserializeArgs<SP>) -> Result<Value, SenderAttributableError>
+    (args: &DeserializeArgs<SP>) -> Result<Value, MaybeAttributableError<SenderError>>
 );
 
 #[derive_where::derive_where(Debug, Clone)]

--- a/ayatori/src/entities/message.rs
+++ b/ayatori/src/entities/message.rs
@@ -56,6 +56,8 @@ impl From<RuntimeError> for VerificationError {
     }
 }
 
+impl core::error::Error for VerificationError {}
+
 fn hash_serialized_value<D: Digest>(value: &SerializedValue) -> Result<digest::Output<D>, RuntimeError> {
     let value_len =
         u64::try_from(value.as_ref().len()).map_err(|_| RuntimeError::new("Message size exceeds 2^64 bytes"))?;

--- a/ayatori/src/entities/message.rs
+++ b/ayatori/src/entities/message.rs
@@ -9,7 +9,10 @@ use signature::{
 };
 
 use super::{errors::RuntimeError, session_id::SessionId, tag::FullName, value::SerializedValue};
-use crate::traits::{SessionParameters, WireFormat};
+use crate::{
+    error::TraceableResult,
+    traits::{SessionParameters, WireFormat},
+};
 
 /// Metadata of a signed value.
 #[derive_where::derive_where(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -67,7 +70,10 @@ fn hash_value_hash_and_metadata<SP: SessionParameters>(
     metadata: &ValueMetadata<SP>,
 ) -> Result<SP::Digest, RuntimeError> {
     Ok(SP::Digest::new_with_prefix(b"SignedValueDigest")
-        .chain_update(<SP::WireFormat as WireFormat>::serialize(metadata)?)
+        .chain_update(
+            <SP::WireFormat as WireFormat>::serialize(metadata)
+                .or_with_context(|| format!("Failed to serialize metadata for value `{}`", metadata.full_name()))?,
+        )
         .chain_update(value_hash.as_ref()))
 }
 
@@ -124,7 +130,8 @@ impl<SP: SessionParameters> SignedValue<SP> {
             destination: destination.clone(),
             session_id: session_id.clone(),
         };
-        let digest = hash_value_and_metadata::<SP>(&value, &metadata)?;
+        let digest = hash_value_and_metadata::<SP>(&value, &metadata)
+            .or_with_context(|| format!("Failed to create a signed value `{name}`"))?;
         let mut typed_rng = Rng(rng);
         let signature = signer
             .try_sign_digest_with_rng(&mut typed_rng, digest)
@@ -143,7 +150,8 @@ impl<SP: SessionParameters> SignedValue<SP> {
     }
 
     fn verify_inner(&self) -> Result<(), VerificationError> {
-        let digest = hash_value_and_metadata::<SP>(&self.value, &self.metadata)?;
+        let digest = hash_value_and_metadata::<SP>(&self.value, &self.metadata)
+            .or_with_context(|| format!("Failed to verify a signed value `{}`", self.metadata.full_name()))?;
         self.source
             .verify_digest(digest, &self.signature)
             .map_err(|_err| VerificationError::SignatureMismatch)
@@ -194,7 +202,8 @@ impl<SP: SessionParameters> SignedHash<SP> {
     }
 
     fn verify_inner(&self) -> Result<(), VerificationError> {
-        let digest = hash_value_hash_and_metadata::<SP>(&self.hash, &self.metadata)?;
+        let digest = hash_value_hash_and_metadata::<SP>(&self.hash, &self.metadata)
+            .or_with_context(|| format!("Failed to verify a signed hash {}", self.metadata.full_name()))?;
         self.source
             .verify_digest(digest, &self.signature)
             .map_err(|_err| VerificationError::SignatureMismatch)
@@ -237,7 +246,12 @@ impl<SP: SessionParameters> VerifiedValue<SP> {
 
     /// Returns `true` if the hash in `other` is equal to the hash of this value.
     pub fn payload_hash_matches(&self, other: &SignedHash<SP>) -> Result<bool, RuntimeError> {
-        let value_hash = hash_serialized_value::<SP::Digest>(&self.value)?;
+        let value_hash = hash_serialized_value::<SP::Digest>(&self.value).or_with_context(|| {
+            format!(
+                "Failed to check if payload's hash matches for value `{}`",
+                self.metadata.full_name()
+            )
+        })?;
         Ok(value_hash.as_ref() == other.hash.as_ref())
     }
 
@@ -254,7 +268,12 @@ impl<SP: SessionParameters> VerifiedValue<SP> {
     /// Turns this into a signed hash (essentially replacing the actual value with its hash,
     /// keeping the metadata intact).
     pub fn to_signed_hash(&self) -> Result<SignedHash<SP>, RuntimeError> {
-        let value_hash = hash_serialized_value::<SP::Digest>(&self.value)?;
+        let value_hash = hash_serialized_value::<SP::Digest>(&self.value).or_with_context(|| {
+            format!(
+                "Failed to convert verified value `{}` to signed hash",
+                self.metadata.full_name()
+            )
+        })?;
         Ok(SignedHash {
             signature: self.signature.clone(),
             source: self.source.clone(),

--- a/ayatori/src/entities/value.rs
+++ b/ayatori/src/entities/value.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_encoded_bytes::{Hex, SliceLike};
 
 use super::errors::RuntimeError;
-use crate::traits::WireFormat;
+use crate::{error::TraceableResult, traits::WireFormat};
 
 /*
 We need a dyn trait that both supports downcast for `Arc`s (like `Any` does),
@@ -147,8 +147,12 @@ trait DynAdapter<F: WireFormat>: Send + Sync {
 
 impl<F: WireFormat, T: Erasable + Serialize + for<'de> Deserialize<'de>> DynAdapter<F> for DynAdapterHolder<F, T> {
     fn serialize(&self, value: &Value) -> Result<SerializedValue, RuntimeError> {
-        let typed_value = value.downcast_ref::<T>()?;
-        Ok(SerializedValue::new(F::serialize(typed_value)?))
+        let typed_value = value
+            .downcast_ref::<T>()
+            .or_with_context(|| "Failed to downcast an erased value".into())?;
+        Ok(SerializedValue::new(
+            F::serialize(typed_value).or_with_context(|| "Failed to serialize an erased value".into())?,
+        ))
     }
 
     fn deserialize(&self, serialized_value: &SerializedValue) -> Result<Value, DeserializationError> {

--- a/ayatori/src/error.rs
+++ b/ayatori/src/error.rs
@@ -1,0 +1,92 @@
+use alloc::{string::String, vec::Vec};
+use core::{
+    fmt::{self, Debug, Display},
+    panic::Location,
+};
+
+#[derive(Debug, Clone)]
+struct Frame {
+    context: String,
+    location: &'static Location<'static>,
+}
+
+/// An error with an associated (explicitly built) traceback.
+#[derive(Clone)]
+pub(crate) struct TracedError {
+    trace: Vec<Frame>,
+    top: Frame,
+}
+
+impl TracedError {
+    #[track_caller]
+    pub fn new(error: impl Into<String>) -> Self {
+        let location = Location::caller();
+        Self {
+            trace: Vec::new(),
+            top: Frame {
+                context: error.into(),
+                location,
+            },
+        }
+    }
+
+    #[track_caller]
+    fn with_context(self, context: impl Into<String>) -> Self {
+        let location = Location::caller();
+        let mut trace = self.trace;
+        trace.push(self.top);
+        Self {
+            trace,
+            top: Frame {
+                context: context.into(),
+                location,
+            },
+        }
+    }
+}
+
+impl Debug for TracedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        writeln!(f, "{} at {}", self.top.context, self.top.location)?;
+        for frame in &self.trace {
+            writeln!(f, "  {} at {}", frame.context, frame.location)?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for TracedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.top.context)
+    }
+}
+
+pub(crate) trait Traceable {
+    fn with_context(self, context: impl Into<String>) -> Self;
+}
+
+impl Traceable for TracedError {
+    #[track_caller]
+    fn with_context(self, context: impl Into<String>) -> Self {
+        self.with_context(context)
+    }
+}
+
+pub(crate) trait TraceableResult {
+    fn or_with_context(self, context: impl FnOnce() -> String) -> Self;
+}
+
+impl<T, E> TraceableResult for Result<T, E>
+where
+    E: Traceable,
+{
+    #[track_caller]
+    fn or_with_context(self, context: impl FnOnce() -> String) -> Self {
+        // Note: we don't use `map_err()` so that `#[track_caller]` in `Traced::trace_and_map()`
+        // could pick up this method's caller.
+        match self {
+            Ok(value) => Ok(value),
+            Err(error) => Err(error.with_context(context())),
+        }
+    }
+}

--- a/ayatori/src/execution.rs
+++ b/ayatori/src/execution.rs
@@ -9,6 +9,6 @@ pub mod tokio;
 pub use evidence::Evidence;
 pub use session::{
     DuplicateMessagesError, InvalidMessageError, MessageAttributableError, ReachedOutputSession, Session,
-    SessionOutcome, SessionReport, SessionState,
+    SessionOutcome, SessionReport, SessionState, UnfinishableOutcome,
 };
 pub use task::Task;

--- a/ayatori/src/execution.rs
+++ b/ayatori/src/execution.rs
@@ -8,7 +8,7 @@ pub mod tokio;
 
 pub use evidence::Evidence;
 pub use session::{
-    DuplicateMessagesError, InvalidMessageError, MessageAttributableError, ReachedOutputSession, Session,
+    DuplicateMessagesError, InvalidMessageError, MessageAttributableError, ReachedOutputSession, Session, SessionError,
     SessionReport, SessionState, StalledSession, TaskError,
 };
 pub use task::Task;

--- a/ayatori/src/execution.rs
+++ b/ayatori/src/execution.rs
@@ -8,7 +8,7 @@ pub mod tokio;
 
 pub use evidence::Evidence;
 pub use session::{
-    DuplicateMessagesError, InvalidMessageError, MessageAttributableError, ReachedOutputSession, Session, SessionError,
-    SessionReport, SessionState, StalledSession, TaskError,
+    DuplicateMessagesError, InvalidMessageError, MessageAttributableError, ReachedOutputSession, Session,
+    SessionOutcome, SessionReport, SessionState,
 };
 pub use task::Task;

--- a/ayatori/src/execution/evidence.rs
+++ b/ayatori/src/execution/evidence.rs
@@ -6,7 +6,7 @@ use alloc::{
 use core::marker::PhantomData;
 
 use super::{
-    session::{Session, SessionState, TaskError},
+    session::{Session, SessionState},
     task::Task,
 };
 use crate::{
@@ -291,8 +291,10 @@ fn run_evidence_verification_session<SP: SessionParameters, P: ExecutableProtoco
     );
 
     while let Some(task) = session.make_task()? {
-        let task_result = match task {
-            Task::Deterministic(task) => session.add_result(task.execute()),
+        let new_state = match task {
+            Task::Deterministic(task) => session
+                .add_result(task.execute())
+                .or_with_context(|| "Failed to execute a task".into())?,
             Task::Randomized(_task) => {
                 return Ok(EvidenceVerdict::invalid(
                     "Unexpected RNG-based computation when reproducing the failure",
@@ -306,31 +308,30 @@ fn run_evidence_verification_session<SP: SessionParameters, P: ExecutableProtoco
             }
         };
 
-        match task_result {
-            Ok(()) => {}
-            Err(TaskError::Runtime(error)) => {
-                return Err(error.with_context("Runtime error when executing a task"));
-            }
-            Err(TaskError::Spurious(error)) => {
-                return Ok(EvidenceVerdict::invalid(format!(
-                    "Unexpected spurious error: {error:?}"
-                )));
-            }
-            Err(TaskError::MessageAttributable(error)) => {
+        session = match new_state {
+            SessionState::InProgress(session) => session,
+            SessionState::InProgressWithMessageError { error, .. } => {
                 return Ok(EvidenceVerdict::invalid(format!(
                     "Unexpected message-attributable error: {error:?}"
+                )));
+            }
+            SessionState::ReachedOutput(success) => {
+                return success
+                    .finalize_with_evidence_verdict()
+                    .or_with_context(|| "Failed to finalize the reproduction session".into());
+            }
+            SessionState::Unfinishable(report) => {
+                return Ok(EvidenceVerdict::invalid(format!(
+                    "The execution was unfinishable (outcome: {})",
+                    report.outcome
                 )));
             }
         }
     }
 
-    match session.try_finalize() {
-        SessionState::InProgress(_session) => Ok(EvidenceVerdict::invalid("The execution did not finish")),
-        SessionState::ReachedOutput(success) => success
-            .finalize_with_evidence_verdict()
-            .or_with_context(|| "Failed to finalize the reproduction session".into()),
-        SessionState::Stalled(_stalled) => Ok(EvidenceVerdict::invalid("The execution was stalled")),
-    }
+    Ok(EvidenceVerdict::invalid(
+        "All tasks were executed, but the session did not reached the result",
+    ))
 }
 
 #[derive_where::derive_where(Debug, Clone, Serialize, Deserialize)]

--- a/ayatori/src/execution/evidence.rs
+++ b/ayatori/src/execution/evidence.rs
@@ -292,8 +292,8 @@ fn run_evidence_verification_session<SP: SessionParameters, P: ExecutableProtoco
 
     while let Some(task) = session.make_task()? {
         let task_result = match task {
-            Task::Compute(task) => session.add_result(task.execute()),
-            Task::ComputeWithRng(_task) => {
+            Task::Deterministic(task) => session.add_result(task.execute()),
+            Task::Randomized(_task) => {
                 return Ok(EvidenceVerdict::invalid(
                     "Unexpected RNG-based computation when reproducing the failure",
                 ));

--- a/ayatori/src/execution/evidence.rs
+++ b/ayatori/src/execution/evidence.rs
@@ -292,7 +292,7 @@ fn run_evidence_verification_session<SP: SessionParameters, P: ExecutableProtoco
 
     while let Some(task) = session.make_task()? {
         let task_result = match task {
-            Task::Compute(task) => session.add_result(task.compute()),
+            Task::Compute(task) => session.add_result(task.execute()),
             Task::ComputeWithRng(_task) => {
                 return Ok(EvidenceVerdict::invalid(
                     "Unexpected RNG-based computation when reproducing the failure",

--- a/ayatori/src/execution/evidence.rs
+++ b/ayatori/src/execution/evidence.rs
@@ -14,6 +14,7 @@ use crate::{
         AnyTagRef, EvidenceVerdict, MappingTag, Message, MessageId, RuntimeError, SenderError, SenderErrorWithReveal,
         SessionId, SignedValue, ThirdPartyError, UnattributableError, VerificationError, VerifiedValue,
     },
+    error::{Traceable, TraceableResult},
     graph_representation::{AnyNode, ArgNodes, ComputeMappingKind, PartyBuildData},
     traits::{ExecutableProtocol, SessionParameters},
 };
@@ -143,16 +144,24 @@ impl<SP: SessionParameters> ConflictingMessagesEvidence<SP> {
         let first_value = match self.first.clone().verify_and_unpack() {
             Ok(value) => value,
             Err(VerificationError::SignatureMismatch) => {
-                return Ok(EvidenceVerdict::invalid("Failed to verify the first value"));
+                return Ok(EvidenceVerdict::invalid(
+                    "Signature mismatch when verifying the first value",
+                ));
             }
-            Err(VerificationError::Runtime(error)) => return Err(error),
+            Err(VerificationError::Runtime(error)) => {
+                return Err(error.with_context("Failed to verify the first value"));
+            }
         };
         let second_value = match self.second.clone().verify_and_unpack() {
             Ok(value) => value,
             Err(VerificationError::SignatureMismatch) => {
-                return Ok(EvidenceVerdict::invalid("Failed to verify the second value"));
+                return Ok(EvidenceVerdict::invalid(
+                    "Signature mismatch when verifying the second value",
+                ));
             }
-            Err(VerificationError::Runtime(error)) => return Err(error),
+            Err(VerificationError::Runtime(error)) => {
+                return Err(error.with_context("Failed to verify the second value"));
+            }
         };
 
         if first_value == second_value {
@@ -205,7 +214,8 @@ impl<SP: SessionParameters, P: ExecutableProtocol<SP>> SenderErrorEvidence<SP, P
             guilty_party,
             shared_data,
             None,
-        )?;
+        )
+        .or_with_context(|| "Failed to build the reproduction subtree".into())?;
 
         run_evidence_verification_session(session, &self.reported_by, guilty_party, &self.signed_values)
     }
@@ -253,7 +263,8 @@ impl<SP: SessionParameters, P: ExecutableProtocol<SP>> SenderErrorWithRevealEvid
             guilty_party,
             shared_data,
             Some(&self.error.associated_data),
-        )?;
+        )
+        .or_with_context(|| "Failed to build the reproduction subtree".into())?;
 
         run_evidence_verification_session(session, &self.reported_by, guilty_party, &self.signed_values)
     }
@@ -297,7 +308,9 @@ fn run_evidence_verification_session<SP: SessionParameters, P: ExecutableProtoco
 
         match task_result {
             Ok(()) => {}
-            Err(TaskError::Unattributable(UnattributableError::Runtime(error))) => return Err(error),
+            Err(TaskError::Unattributable(UnattributableError::Runtime(error))) => {
+                return Err(error.with_context("Runtime error when executing a task"));
+            }
             Err(TaskError::Unattributable(UnattributableError::Spurious(error))) => {
                 return Ok(EvidenceVerdict::invalid(format!(
                     "Unexpected spurious error: {error:?}"
@@ -313,7 +326,9 @@ fn run_evidence_verification_session<SP: SessionParameters, P: ExecutableProtoco
 
     match session.try_finalize() {
         SessionState::InProgress(_session) => Ok(EvidenceVerdict::invalid("The execution did not finish")),
-        SessionState::ReachedOutput(success) => success.finalize_with_evidence_verdict(),
+        SessionState::ReachedOutput(success) => success
+            .finalize_with_evidence_verdict()
+            .or_with_context(|| "Failed to finalize the reproduction session".into()),
         SessionState::Stalled(_stalled) => Ok(EvidenceVerdict::invalid("The execution was stalled")),
     }
 }
@@ -350,7 +365,8 @@ impl<SP: SessionParameters, P: ExecutableProtocol<SP>> ThirdPartyErrorEvidence<S
         let signature = P::signature();
         let arg_nodes = ArgNodes::new(&signature);
         let party_build_data = PartyBuildData::new(&self.reported_by);
-        let output = P::build(&party_build_data, &build_data, arg_nodes)?;
+        let output = P::build(&party_build_data, &build_data, arg_nodes)
+            .or_with_context(|| "Failed to build the protocol graph".into())?;
         let any_node = Into::<AnyNode<SP>>::into(output);
         let Some(node) = any_node.find_subnode(AnyTagRef::Mapping(self.failed_at.as_ref())) else {
             return Ok(EvidenceVerdict::invalid(format!(
@@ -367,6 +383,8 @@ impl<SP: SessionParameters, P: ExecutableProtocol<SP>> ThirdPartyErrorEvidence<S
             return Ok(EvidenceVerdict::invalid("Invalid function type"));
         };
 
-        verification.call(guilty_party, session_id, &self.error.associated_data)
+        verification
+            .call(guilty_party, session_id, &self.error.associated_data)
+            .or_with_context(|| "Failed to run the associated verification function".into())
     }
 }

--- a/ayatori/src/execution/evidence.rs
+++ b/ayatori/src/execution/evidence.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::{
     entities::{
         AnyTagRef, EvidenceVerdict, MappingTag, Message, MessageId, RuntimeError, SenderError, SenderErrorWithReveal,
-        SessionId, SignedValue, ThirdPartyError, UnattributableError, VerificationError, VerifiedValue,
+        SessionId, SignedValue, ThirdPartyError, VerificationError, VerifiedValue,
     },
     error::{Traceable, TraceableResult},
     graph_representation::{AnyNode, ArgNodes, ComputeMappingKind, PartyBuildData},
@@ -308,10 +308,10 @@ fn run_evidence_verification_session<SP: SessionParameters, P: ExecutableProtoco
 
         match task_result {
             Ok(()) => {}
-            Err(TaskError::Unattributable(UnattributableError::Runtime(error))) => {
+            Err(TaskError::Runtime(error)) => {
                 return Err(error.with_context("Runtime error when executing a task"));
             }
-            Err(TaskError::Unattributable(UnattributableError::Spurious(error))) => {
+            Err(TaskError::Spurious(error)) => {
                 return Ok(EvidenceVerdict::invalid(format!(
                     "Unexpected spurious error: {error:?}"
                 )));

--- a/ayatori/src/execution/evidence.rs
+++ b/ayatori/src/execution/evidence.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::{
     entities::{
         AnyTagRef, EvidenceVerdict, MappingTag, Message, MessageId, RuntimeError, SenderError, SenderErrorWithReveal,
-        SessionId, SignedValue, ThirdPartyError, VerificationError, VerifiedValue,
+        SessionId, SignedValue, StoredThirdPartyError, VerificationError, VerifiedValue,
     },
     error::{Traceable, TraceableResult},
     graph_representation::{AnyNode, ArgNodes, ComputeMappingKind, PartyBuildData},
@@ -262,7 +262,7 @@ impl<SP: SessionParameters, P: ExecutableProtocol<SP>> SenderErrorWithRevealEvid
             &self.reported_by,
             guilty_party,
             shared_data,
-            Some(&self.error.associated_data),
+            Some(self.error.associated_data()),
         )
         .or_with_context(|| "Failed to build the reproduction subtree".into())?;
 
@@ -337,12 +337,12 @@ fn run_evidence_verification_session<SP: SessionParameters, P: ExecutableProtoco
 pub(crate) struct ThirdPartyErrorEvidence<SP: SessionParameters, P: ExecutableProtocol<SP>> {
     reported_by: SP::Verifier,
     failed_at: MappingTag,
-    error: ThirdPartyError<SP>,
+    error: StoredThirdPartyError<SP>,
     phantom: PhantomData<fn() -> (SP, P)>,
 }
 
 impl<SP: SessionParameters, P: ExecutableProtocol<SP>> ThirdPartyErrorEvidence<SP, P> {
-    pub fn new(reported_by: &SP::Verifier, failed_at: &MappingTag, error: ThirdPartyError<SP>) -> Self {
+    pub fn new(reported_by: &SP::Verifier, failed_at: &MappingTag, error: StoredThirdPartyError<SP>) -> Self {
         Self {
             reported_by: reported_by.clone(),
             failed_at: failed_at.clone(),
@@ -384,7 +384,7 @@ impl<SP: SessionParameters, P: ExecutableProtocol<SP>> ThirdPartyErrorEvidence<S
         };
 
         verification
-            .call(guilty_party, session_id, &self.error.associated_data)
+            .call(guilty_party, session_id, self.error.associated_data())
             .or_with_context(|| "Failed to run the associated verification function".into())
     }
 }

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -16,7 +16,12 @@ use super::{
         ThirdPartyErrorEvidence,
     },
     storage::Storage,
-    task::{PreprocessingTask, Task, TaskResult, TaskResultEnum},
+    task::{
+        DeserializeElementTask, ElementSenderAttributableTask, ElementSenderAttributableWithRevealTask,
+        ElementThirdPartyAttributableTask, ElementUnattributableTask, PreprocessMessageTask,
+        RngElementUnattributableTask, RngScalarUnattributableTask, ScalarUnattributableOptionalTask,
+        ScalarUnattributableTask, SendTask, SerializeAndSignElementTask, Task, TaskResult, TaskResultEnum,
+    },
 };
 #[cfg(feature = "dev")]
 use crate::dev::Replacement;
@@ -57,7 +62,7 @@ pub struct Session<SP: SessionParameters, P: ExecutableProtocol<SP>> {
     provable_errors: BTreeMap<SP::Verifier, Evidence<SP, P>>,
     attributable_errors: BTreeMap<SP::Verifier, String>,
     external_bans: BTreeMap<SP::Verifier, String>,
-    preprocessing_tasks: Vec<PreprocessingTask<SP>>,
+    preprocessing_tasks: Vec<PreprocessMessageTask<SP>>,
     phantom: PhantomData<fn() -> P>,
 }
 
@@ -316,7 +321,7 @@ where
     pub fn add_message(&mut self, message_id: &MessageId<SP>, message: Message<SP>) {
         let tasks = message
             .into_values()
-            .map(|signed_value| PreprocessingTask::new(&self.data, message_id.clone(), signed_value))
+            .map(|signed_value| PreprocessMessageTask::new(&self.data, message_id.clone(), signed_value))
             .collect::<Vec<_>>();
         self.preprocessing_tasks.extend(tasks);
     }
@@ -326,7 +331,7 @@ where
     /// The returned task may be offloaded to a thread pool.
     pub fn make_task(&mut self) -> Result<Option<Task<SP>>, RuntimeError> {
         if let Some(task) = self.preprocessing_tasks.pop() {
-            return Ok(Some(Task::preprocess_message(task)));
+            return Ok(Some(task.into()));
         }
 
         while let Some(action) = self.ruleset.pop_action() {
@@ -340,7 +345,7 @@ where
                         .storage
                         .get_elem(&MappingTag::LocalSigned(to_send), &destination)
                         .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?;
-                    return Ok(Some(Task::direct_message(store_in, destination, signed_value)));
+                    return Ok(Some(SendTask::new(store_in, destination, signed_value).into()));
                 }
                 Action::ComputeScalar {
                     store_in,
@@ -354,13 +359,13 @@ where
                     let args = Args::new(&self.data.id, self.verifier(), arg_values);
                     return Ok(Some(match function {
                         ScalarFunction::Unattributable(function) => {
-                            Task::compute_scalar_unattributable(store_in, function, args)
+                            ScalarUnattributableTask::new(store_in, function, args).into()
                         }
                         ScalarFunction::UnattributableOptional(function) => {
-                            Task::compute_scalar_unattributable_optional(store_in, function, args)
+                            ScalarUnattributableOptionalTask::new(store_in, function, args).into()
                         }
                         ScalarFunction::UnattributableWithRng(function) => {
-                            Task::compute_scalar_unattributable_with_rng(store_in, function, args)
+                            RngScalarUnattributableTask::new(store_in, function, args).into()
                         }
                     }));
                 }
@@ -378,21 +383,20 @@ where
                     let args = Args::new(&self.data.id, self.verifier(), arg_values);
                     return Ok(Some(match function {
                         MappingFunction::Unattributable(function) => {
-                            Task::compute_mapping_elem_unattributable(store_in, index, function, args)
+                            ElementUnattributableTask::new(store_in, function, index, args).into()
                         }
                         MappingFunction::UnattributableWithRng(function) => {
-                            Task::compute_mapping_elem_unattributable_with_rng(store_in, index, function, args)
+                            RngElementUnattributableTask::new(store_in, function, index, args).into()
                         }
                         MappingFunction::SenderAttributable(function) => {
-                            Task::compute_mapping_elem_sender_attributable(store_in, index, function, args, on_error)
+                            ElementSenderAttributableTask::new(store_in, function, index, args, on_error).into()
                         }
                         MappingFunction::SenderAttributableWithReveal(function) => {
-                            Task::compute_mapping_elem_sender_attributable_with_reveal(
-                                store_in, index, function, args, on_error,
-                            )
+                            ElementSenderAttributableWithRevealTask::new(store_in, function, index, args, on_error)
+                                .into()
                         }
                         MappingFunction::ThirdPartyAttributable(function) => {
-                            Task::compute_mapping_elem_third_party_attributable(store_in, index, function, args)
+                            ElementThirdPartyAttributableTask::new(store_in, function, index, args).into()
                         }
                     }));
                 }
@@ -419,9 +423,9 @@ where
                     .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?;
 
                     let args = SerializeArgs::new(signer, &self.data.id, message_name, serde_adapter, value);
-                    return Ok(Some(Task::compute_serialize_and_sign_elem(
-                        store_in, index, function, args,
-                    )));
+                    return Ok(Some(
+                        SerializeAndSignElementTask::new(store_in, function, index, args).into(),
+                    ));
                 }
                 Action::ComputeDeserializeElement {
                     store_in,
@@ -440,9 +444,9 @@ where
                         RuntimeError::expect(format!("{message_name} does not have expected senders"))
                     })?;
                     let args = DeserializeArgs::new(&expected_senders, serde_adapter, value);
-                    return Ok(Some(Task::compute_deserialize_elem(
-                        store_in, index, function, args, on_error,
-                    )));
+                    return Ok(Some(
+                        DeserializeElementTask::new(store_in, function, index, args, on_error).into(),
+                    ));
                 }
                 Action::MergeScalar { store_in, left, right } => {
                     self.add_scalar(
@@ -472,7 +476,7 @@ where
 
     /// Registers the result of an executed task.
     pub fn add_result(&mut self, result: TaskResult<SP>) -> Result<(), TaskError<SP>> {
-        match result.into_enum() {
+        match result.into_inner() {
             TaskResultEnum::NoActionNeeded => {}
             TaskResultEnum::RuntimeError(error) => return Err(TaskError::Runtime(error)),
             TaskResultEnum::SpuriousError(error) => return Err(TaskError::Spurious(error)),
@@ -484,10 +488,10 @@ where
             }
             TaskResultEnum::ComputedMappingElement {
                 store_in,
-                source,
+                index,
                 result,
             } => {
-                self.add_element(&store_in, &source, result)?;
+                self.add_element(&store_in, &index, result)?;
             }
             TaskResultEnum::SenderError {
                 store_in,

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -1,7 +1,7 @@
 use alloc::{
     collections::{BTreeMap, BTreeSet},
     format,
-    string::{String, ToString},
+    string::String,
     sync::Arc,
     vec::Vec,
 };
@@ -479,8 +479,8 @@ where
             AddTaskResult::MessageAttributableError(error) => {
                 SessionState::InProgressWithMessageError { session: self, error }
             }
-            AddTaskResult::SpuriousError(error) => {
-                let report = self.make_report(SessionOutcome::SpuriousError(error.to_string()));
+            AddTaskResult::SpuriousError { store_in, error } => {
+                let report = self.make_report(SessionOutcome::SpuriousError(SpuriousErrorOutcome { store_in, error }));
                 SessionState::Unfinishable(report)
             }
         })
@@ -491,7 +491,7 @@ where
         match result.into_inner() {
             TaskResultEnum::NoActionNeeded => Ok(AddTaskResult::StateDidNotChange),
             TaskResultEnum::RuntimeError(error) => Err(error.with_context("Task returned a runtime error")),
-            TaskResultEnum::SpuriousError(error) => Ok(AddTaskResult::SpuriousError(error)),
+            TaskResultEnum::SpuriousError { store_in, error } => Ok(AddTaskResult::SpuriousError { store_in, error }),
             TaskResultEnum::Sent { store_in, destination } => {
                 self.add_element(&store_in, &destination, Value::new(()))?;
                 Ok(AddTaskResult::StateChanged)
@@ -829,14 +829,14 @@ pub enum SessionOutcome<SP: SessionParameters, P: ExecutableProtocol<SP>> {
     Unfinishable(UnfinishableOutcome),
     /// A [`SpuriousError`] error occurred in one of the computations.
     #[displaydoc("Spurious error: {0}")]
-    SpuriousError(String), // TODO: specify at which tag it occurred
+    SpuriousError(SpuriousErrorOutcome),
 }
 
 enum AddTaskResult<SP: SessionParameters> {
     StateChanged,
     StateDidNotChange,
     MessageAttributableError(MessageAttributableError<SP>),
-    SpuriousError(SpuriousError),
+    SpuriousError { store_in: AnyTag, error: SpuriousError },
 }
 
 /// Contains the specifics about why the session was impossible to finalize.
@@ -846,5 +846,18 @@ pub struct UnfinishableOutcome(Vec<CollectedTag>);
 impl Display for UnfinishableOutcome {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Impossible to collect: {}", self.0.iter().join(", "))
+    }
+}
+
+/// Contains the specifics about why the session was impossible to finalize.
+#[derive(Debug, Clone)]
+pub struct SpuriousErrorOutcome {
+    store_in: AnyTag,
+    error: SpuriousError,
+}
+
+impl Display for SpuriousErrorOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "Spurious error when calculating {}: {}", self.store_in, self.error)
     }
 }

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -467,7 +467,7 @@ where
                     RulesetState::InProgress => SessionState::InProgress(self),
                     RulesetState::ReachedOutput => SessionState::ReachedOutput(ReachedOutputSession(self)),
                     RulesetState::ImpossibleToCollect(tag) => {
-                        let report = self.make_report(SessionOutcome::ImpossibleToCollect(tag.to_string()));
+                        let report = self.make_report(SessionOutcome::Unfinishable(tag.to_string()));
                         SessionState::Unfinishable(report)
                     }
                 }
@@ -687,7 +687,6 @@ where
     /// Destroys the session and returns the report containing the output
     /// and recorded failures of remote parties (if any).
     pub fn finalize(self) -> Result<SessionReport<SP, P>, RuntimeError> {
-        // TODO: this should be infallible?
         self.0.finalize_with_success()
     }
 
@@ -810,13 +809,6 @@ impl<SP: SessionParameters, P: ExecutableProtocol<SP>> SessionReport<SP, P> {
             None
         }
     }
-
-    /// Returns `true` if the session was terminated due to being unfinishable
-    /// (enough nodes were banned to make some collection nodes impossible to trigger).
-    pub fn is_unfinishable(&self) -> bool {
-        // TODO: change function name?
-        matches!(self.outcome, SessionOutcome::ImpossibleToCollect(..))
-    }
 }
 
 /// Possible session outcomes.
@@ -830,8 +822,8 @@ pub enum SessionOutcome<SP: SessionParameters, P: ExecutableProtocol<SP>> {
     #[displaydoc("Manually terminated")]
     ManuallyTerminated,
     /// Some collect nodes are impossible to finish due to some parties having been banned.
-    #[displaydoc("Impossible to collect: {0}")]
-    ImpossibleToCollect(String), // TODO: specify the number of banned parties or something?
+    #[displaydoc("Unfinishable: {0}")]
+    Unfinishable(String), // TODO: specify the number of banned parties or something?
     /// A [`SpuriousError`] error occurred in one of the computations.
     #[displaydoc("Spurious error: {0}")]
     SpuriousError(String), // TODO: specify at which tag it occurred

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -26,6 +26,7 @@ use crate::{
         FullName, MappingFunction, MappingTag, Message, MessageId, RemoteSignedTag, RuntimeError, ScalarFunction,
         ScalarTag, SerializeArgs, SessionId, UnattributableError, Value, VerifiedValue,
     },
+    error::TraceableResult,
     flat_representation::{Action, OnError, Ruleset, RulesetState},
     graph_representation::{AnyNode, ArgNodes, OutputNode, PartyBuildData, PrivateInputs, PublicInputs},
     traits::{ExecutableProtocol, SessionParameters},
@@ -89,7 +90,8 @@ where
         let local_participants = BTreeSet::from([verifier.clone()]);
         let public_inputs = P::make_public_inputs(shared_data);
 
-        let ruleset = Ruleset::new(output_node, &private_inputs.names())?;
+        let ruleset = Ruleset::new(output_node, &private_inputs.names())
+            .or_with_context(|| "Failed to build the ruleset".into())?;
         let storage = Storage::new();
 
         let expected_messages = ruleset.expected_messages().clone();
@@ -112,7 +114,9 @@ where
             phantom: PhantomData,
         };
 
-        session.fill_inputs(public_inputs, private_inputs)?;
+        session
+            .fill_inputs(public_inputs, private_inputs)
+            .or_with_context(|| "Failed to associate protocol inputs with the input nodes".into())?;
 
         Ok(session)
     }
@@ -148,13 +152,15 @@ where
 
         for (name, value) in public_values {
             if let Some(store_in) = arguments.get(&name) {
-                self.add_scalar(&ScalarTag::Argument(store_in.clone()), value)?;
+                self.add_scalar(&ScalarTag::Argument(store_in.clone()), value)
+                    .or_with_context(|| format!("Failed to add the private input `{store_in}` to the storage"))?;
             }
         }
 
         for (name, value) in private_values {
             if let Some(store_in) = arguments.get(&name) {
-                self.add_scalar(&ScalarTag::Argument(store_in.clone()), value)?;
+                self.add_scalar(&ScalarTag::Argument(store_in.clone()), value)
+                    .or_with_context(|| format!("Failed to add the public input `{store_in}` to the storage"))?;
             }
         }
 
@@ -169,7 +175,8 @@ where
         shared_data: &P::SharedData,
     ) -> Result<Self, RuntimeError> {
         let verifier = signer.verifying_key();
-        let output_node = make_tree::<SP, P>(&verifier, shared_data)?;
+        let output_node = make_tree::<SP, P>(&verifier, shared_data)
+            .or_with_context(|| "Failed to build the protocol graph".into())?;
         let private_inputs = P::make_private_inputs(private_data);
         Self::new_inner(id, Some(signer), &verifier, &output_node, private_inputs, shared_data)
     }
@@ -182,11 +189,11 @@ where
         shared_data: &P::SharedData,
         associated_data: Option<&AssociatedData<SP>>,
     ) -> Result<Self, RuntimeError> {
-        let output_node = AnyNode::from(make_tree::<SP, P>(reported_by, shared_data)?).get_reproduction_subtree(
-            subtree_root,
-            guilty_party,
-            associated_data,
-        )?;
+        let full_graph = make_tree::<SP, P>(reported_by, shared_data)
+            .or_with_context(|| "Failed to build the protocol graph".into())?;
+        let output_node = AnyNode::from(full_graph)
+            .get_reproduction_subtree(subtree_root, guilty_party, associated_data)
+            .or_with_context(|| format!("Failed to extract the reproduction subtree for node `{subtree_root}`"))?;
         Self::new_inner(id, None, reported_by, &output_node, PrivateInputs::new(), shared_data)
     }
 
@@ -200,9 +207,15 @@ where
         replacements: &[&Replacement<SP>],
     ) -> Result<Self, RuntimeError> {
         let verifier = signer.verifying_key();
-        let mut output_node = make_tree::<SP, P>(&verifier, shared_data)?;
+        let mut output_node = make_tree::<SP, P>(&verifier, shared_data)
+            .or_with_context(|| "Failed to build the protocol graph".into())?;
         for replacement in replacements {
-            output_node = replacement.apply(&output_node)?;
+            output_node = replacement.apply(&output_node).or_with_context(|| {
+                format!(
+                    "Failed to build apply the replacement for node `{}`",
+                    output_node.store_in()
+                )
+            })?;
         }
         let private_inputs = P::make_private_inputs(private_data);
         Self::new_inner(id, Some(signer), &verifier, &output_node, private_inputs, shared_data)
@@ -214,13 +227,17 @@ where
     }
 
     fn add_scalar(&mut self, store_in: &ScalarTag, value: Value) -> Result<(), RuntimeError> {
-        self.storage.set_scalar(store_in, value)?;
+        self.storage
+            .set_scalar(store_in, value)
+            .or_with_context(|| format!("Failed to store the scalar result of `{store_in}`"))?;
         self.ruleset.update_with_scalar_ready(store_in);
         Ok(())
     }
 
     fn add_element(&mut self, store_in: &MappingTag, id: &SP::Verifier, value: Value) -> Result<(), RuntimeError> {
-        self.storage.set_elem(store_in, id, value)?;
+        self.storage
+            .set_elem(store_in, id, value)
+            .or_with_context(|| format!("Failed to store a mapping element result of `{store_in}`"))?;
         self.ruleset.update_with_element_ready(store_in, id);
         Ok(())
     }
@@ -253,13 +270,19 @@ where
     }
 
     pub(crate) fn get_output<T: Erasable + Clone>(&self, output_tag: &ComputedScalarTag) -> Result<T, RuntimeError> {
-        let value = self.storage.get_scalar(&ScalarTag::Computed(output_tag.clone()))?;
-        value.downcast::<T>()
+        let tag = ScalarTag::Computed(output_tag.clone());
+        let value = self
+            .storage
+            .get_scalar(&tag)
+            .or_with_context(|| "Failed to get the output value from storage".into())?;
+        value
+            .downcast::<T>()
+            .or_with_context(|| "Failed to downcast the output value".into())
     }
 
     pub(crate) fn finalize_with_evidence_verdict(self) -> Result<EvidenceVerdict, RuntimeError> {
-        let verdict = self.get_output::<EvidenceVerdict>(self.ruleset.output_tag())?;
-        Ok(verdict)
+        self.get_output::<EvidenceVerdict>(self.ruleset.output_tag())
+            .or_with_context(|| "Failed to extract the evidence verdict".into())
     }
 
     fn finalize_with_success(self) -> Result<SessionReport<SP, P>, RuntimeError> {
@@ -313,7 +336,10 @@ where
                     to_send,
                     destination,
                 } => {
-                    let signed_value = self.storage.get_elem(&MappingTag::LocalSigned(to_send), &destination)?;
+                    let signed_value = self
+                        .storage
+                        .get_elem(&MappingTag::LocalSigned(to_send), &destination)
+                        .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?;
                     return Ok(Some(Task::direct_message(store_in, destination, signed_value)));
                 }
                 Action::ComputeScalar {
@@ -321,7 +347,10 @@ where
                     function,
                     args,
                 } => {
-                    let arg_values = self.storage.get_scalar_args(args)?;
+                    let arg_values = self
+                        .storage
+                        .get_scalar_args(args)
+                        .or_with_context(|| format!("Failed to get the arguments for `{store_in}` from storage"))?;
                     let args = Args::new(&self.data.id, self.verifier(), arg_values);
                     return Ok(Some(match function {
                         ScalarFunction::Unattributable(function) => {
@@ -342,7 +371,10 @@ where
                     args,
                     on_error,
                 } => {
-                    let arg_values = self.storage.get_scalar_or_mapping_args(&index, args)?;
+                    let arg_values = self
+                        .storage
+                        .get_scalar_or_mapping_args(&index, args)
+                        .or_with_context(|| format!("Failed to get the arguments for `{store_in}` from storage"))?;
                     let args = Args::new(&self.data.id, self.verifier(), arg_values);
                     return Ok(Some(match function {
                         MappingFunction::Unattributable(function) => {
@@ -372,14 +404,20 @@ where
                     message_name,
                     serde_adapter,
                 } => {
-                    let signer = self
-                        .signer
-                        .as_ref()
-                        .ok_or_else(|| RuntimeError::new("This session does not contain a signer"))?;
+                    let signer = self.signer.as_ref().ok_or_else(|| {
+                        // This can happen if a serialization node somehow remains
+                        // in an evidence verification subtree.
+                        RuntimeError::new(
+                            "Attempted to execute a serialize-and-sign node in a session without a signer",
+                        )
+                    })?;
+
                     let value = match data {
-                        AnyTag::Scalar(tag) => self.storage.get_scalar(&tag)?,
-                        AnyTag::Mapping(tag) => self.storage.get_elem(&tag, &index)?,
-                    };
+                        AnyTag::Scalar(tag) => self.storage.get_scalar(&tag),
+                        AnyTag::Mapping(tag) => self.storage.get_elem(&tag, &index),
+                    }
+                    .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?;
+
                     let args = SerializeArgs::new(signer, &self.data.id, message_name, serde_adapter, value);
                     return Ok(Some(Task::compute_serialize_and_sign_elem(
                         store_in, index, function, args,
@@ -394,7 +432,10 @@ where
                     serde_adapter,
                     on_error,
                 } => {
-                    let value = self.storage.get_elem(&MappingTag::RemoteSigned(data), &index)?;
+                    let value = self
+                        .storage
+                        .get_elem(&MappingTag::RemoteSigned(data), &index)
+                        .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?;
                     let expected_senders = self.data.expected_senders(&message_name).ok_or_else(|| {
                         RuntimeError::expect(format!("{message_name} does not have expected senders"))
                     })?;
@@ -406,7 +447,9 @@ where
                 Action::MergeScalar { store_in, left, right } => {
                     self.add_scalar(
                         &ScalarTag::Merged(store_in.clone()),
-                        self.storage.get_one_or_both_as_value(&left, &right)?,
+                        self.storage
+                            .get_one_or_both_as_value(&left, &right)
+                            .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?,
                     )?;
                 }
                 Action::Collect {
@@ -416,7 +459,9 @@ where
                 } => {
                     self.add_scalar(
                         &ScalarTag::Collected(store_in.clone()),
-                        self.storage.get_mapping_as_value(&values, &indices)?,
+                        self.storage
+                            .get_mapping_as_value(&values, &indices)
+                            .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?,
                     )?;
                 }
             }
@@ -453,11 +498,34 @@ where
                 OnError::CollectEvidence(message_names) => {
                     let mut signed_values = Vec::new();
                     for name in message_names {
-                        let value = self.storage.get_elem(
-                            &MappingTag::RemoteSigned(RemoteSignedTag::new_with_full_name(&name)),
-                            &guilty_party,
-                        )?;
-                        let signed_value = value.downcast_ref::<VerifiedValue<SP>>()?.clone().unverify();
+                        let value = self
+                            .storage
+                            .get_elem(
+                                &MappingTag::RemoteSigned(RemoteSignedTag::new_with_full_name(&name)),
+                                &guilty_party,
+                            )
+                            .or_with_context(|| {
+                                format!(
+                                    concat!(
+                                        "Failed to get the signed message `{}` ",
+                                        "to attach to the evidence of `{}` failure"
+                                    ),
+                                    name, store_in
+                                )
+                            })?;
+                        let signed_value = value
+                            .downcast_ref::<VerifiedValue<SP>>()
+                            .or_with_context(|| {
+                                format!(
+                                    concat!(
+                                        "Failed to downcast the signed message `{}` ",
+                                        "to attach to the evidence of `{}` failure"
+                                    ),
+                                    name, store_in
+                                )
+                            })?
+                            .clone()
+                            .unverify();
                         signed_values.push(signed_value);
                     }
                     let evidence = EvidenceKind::SenderError(SenderErrorEvidence::new(
@@ -479,11 +547,34 @@ where
                 OnError::CollectEvidence(message_names) => {
                     let mut signed_values = Vec::new();
                     for name in message_names {
-                        let value = self.storage.get_elem(
-                            &MappingTag::RemoteSigned(RemoteSignedTag::new_with_full_name(&name)),
-                            &guilty_party,
-                        )?;
-                        let signed_value = value.downcast_ref::<VerifiedValue<SP>>()?.clone().unverify();
+                        let value = self
+                            .storage
+                            .get_elem(
+                                &MappingTag::RemoteSigned(RemoteSignedTag::new_with_full_name(&name)),
+                                &guilty_party,
+                            )
+                            .or_with_context(|| {
+                                format!(
+                                    concat!(
+                                        "Failed to get the signed message `{}` ",
+                                        "to attach to the evidence of `{}` failure"
+                                    ),
+                                    name, store_in
+                                )
+                            })?;
+                        let signed_value = value
+                            .downcast_ref::<VerifiedValue<SP>>()
+                            .or_with_context(|| {
+                                format!(
+                                    concat!(
+                                        "Failed to downcast the signed message `{}` ",
+                                        "to attach to the evidence of `{}` failure"
+                                    ),
+                                    name, store_in
+                                )
+                            })?
+                            .clone()
+                            .unverify();
                         signed_values.push(signed_value);
                     }
                     let evidence = EvidenceKind::SenderErrorWithReveal(SenderErrorWithRevealEvidence::new(
@@ -510,8 +601,12 @@ where
                 value,
             } => {
                 if let Ok(existing_value) = self.storage.get_elem(&store_in, &source) {
-                    let typed_existing_value = existing_value.downcast_ref::<VerifiedValue<SP>>()?;
-                    let typed_received_value = value.downcast_ref::<VerifiedValue<SP>>()?;
+                    let typed_existing_value = existing_value
+                        .downcast_ref::<VerifiedValue<SP>>()
+                        .or_with_context(|| format!("Failed to downcast a stored signed message `{store_in}`"))?;
+                    let typed_received_value = value
+                        .downcast_ref::<VerifiedValue<SP>>()
+                        .or_with_context(|| format!("Failed to downcast a newly received message `{store_in}`"))?;
 
                     // Both values are signed, contain the same named value, but are different.
                     // This is a provable failure.

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -5,7 +5,10 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
-use core::marker::PhantomData;
+use core::{
+    fmt::{self, Display},
+    marker::PhantomData,
+};
 
 use itertools::Itertools;
 use signature::Keypair;
@@ -27,9 +30,9 @@ use super::{
 use crate::dev::Replacement;
 use crate::{
     entities::{
-        AnyTag, Args, AssociatedData, ComputedScalarTag, DeserializeArgs, Erasable, EvidenceVerdict, FullName,
-        MappingFunction, MappingTag, Message, MessageId, RemoteSignedTag, RuntimeError, ScalarFunction, ScalarTag,
-        SerializeArgs, SessionId, SpuriousError, Value, VerifiedValue,
+        AnyTag, Args, AssociatedData, CollectedTag, ComputedScalarTag, DeserializeArgs, Erasable, EvidenceVerdict,
+        FullName, MappingFunction, MappingTag, Message, MessageId, RemoteSignedTag, RuntimeError, ScalarFunction,
+        ScalarTag, SerializeArgs, SessionId, SpuriousError, Value, VerifiedValue,
     },
     error::{Traceable, TraceableResult},
     flat_representation::{Action, OnError, Ruleset, RulesetState},
@@ -466,8 +469,8 @@ where
                 match state {
                     RulesetState::InProgress => SessionState::InProgress(self),
                     RulesetState::ReachedOutput => SessionState::ReachedOutput(ReachedOutputSession(self)),
-                    RulesetState::ImpossibleToCollect(tag) => {
-                        let report = self.make_report(SessionOutcome::Unfinishable(tag.to_string()));
+                    RulesetState::ImpossibleToCollect(tags) => {
+                        let report = self.make_report(SessionOutcome::Unfinishable(UnfinishableOutcome(tags)));
                         SessionState::Unfinishable(report)
                     }
                 }
@@ -823,7 +826,7 @@ pub enum SessionOutcome<SP: SessionParameters, P: ExecutableProtocol<SP>> {
     ManuallyTerminated,
     /// Some collect nodes are impossible to finish due to some parties having been banned.
     #[displaydoc("Unfinishable: {0}")]
-    Unfinishable(String), // TODO: specify the number of banned parties or something?
+    Unfinishable(UnfinishableOutcome),
     /// A [`SpuriousError`] error occurred in one of the computations.
     #[displaydoc("Spurious error: {0}")]
     SpuriousError(String), // TODO: specify at which tag it occurred
@@ -834,4 +837,14 @@ enum AddTaskResult<SP: SessionParameters> {
     StateDidNotChange,
     MessageAttributableError(MessageAttributableError<SP>),
     SpuriousError(SpuriousError),
+}
+
+/// Contains the specifics about why the session was impossible to finalize.
+#[derive(Debug, Clone)]
+pub struct UnfinishableOutcome(Vec<CollectedTag>);
+
+impl Display for UnfinishableOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "Impossible to collect: {}", self.0.iter().join(", "))
+    }
 }

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -473,7 +473,7 @@ where
     /// Registers the result of an executed task.
     pub fn add_result(&mut self, result: TaskResult<SP>) -> Result<(), TaskError<SP>> {
         match result.into_enum() {
-            TaskResultEnum::Success => {}
+            TaskResultEnum::NoActionNeeded => {}
             TaskResultEnum::RuntimeError { error } => return Err(TaskError::Runtime(error)),
             TaskResultEnum::SpuriousError { error } => return Err(TaskError::Spurious(error)),
             TaskResultEnum::Sent { store_in, destination } => {

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -750,6 +750,8 @@ pub enum MessageAttributableError<SP: SessionParameters> {
     DuplicateMessages(DuplicateMessagesError<SP>),
 }
 
+impl<SP: SessionParameters> core::error::Error for MessageAttributableError<SP> {}
+
 /// A registered message was found to be invalid.
 #[derive_where::derive_where(Debug)]
 #[derive(displaydoc::Display)]
@@ -763,6 +765,8 @@ pub struct InvalidMessageError<SP: SessionParameters> {
     /// The description of the error.
     pub description: String,
 }
+
+impl<SP: SessionParameters> core::error::Error for InvalidMessageError<SP> {}
 
 /// A registered message was found to be a duplicate of a previously registered message.
 #[derive_where::derive_where(Debug)]
@@ -780,6 +784,8 @@ pub struct DuplicateMessagesError<SP: SessionParameters> {
     /// in which case it should be penalized.
     pub second: MessageId<SP>,
 }
+
+impl<SP: SessionParameters> core::error::Error for DuplicateMessagesError<SP> {}
 
 /// The results of a session.
 #[derive_where::derive_where(Debug, Clone)]

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -587,11 +587,8 @@ where
                     self.register_provable_error(Evidence::new(&self.data.id, &guilty_party, evidence));
                 }
             },
-            TaskResultEnum::ThirdPartyError {
-                store_in,
-                guilty_party,
-                error,
-            } => {
+            TaskResultEnum::ThirdPartyError { store_in, error } => {
+                let (guilty_party, error) = error.unpack();
                 let evidence =
                     EvidenceKind::ThirdPartyError(ThirdPartyErrorEvidence::new(&self.verifier, &store_in, error));
                 self.register_provable_error(Evidence::new(&self.data.id, &guilty_party, evidence));

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -1,7 +1,7 @@
 use alloc::{
     collections::{BTreeMap, BTreeSet},
     format,
-    string::String,
+    string::{String, ToString},
     sync::Arc,
     vec::Vec,
 };
@@ -27,11 +27,11 @@ use super::{
 use crate::dev::Replacement;
 use crate::{
     entities::{
-        AnyTag, Args, AssociatedData, CollectedTag, ComputedScalarTag, DeserializeArgs, Erasable, EvidenceVerdict,
-        FullName, MappingFunction, MappingTag, Message, MessageId, RemoteSignedTag, RuntimeError, ScalarFunction,
-        ScalarTag, SerializeArgs, SessionId, SpuriousError, Value, VerifiedValue,
+        AnyTag, Args, AssociatedData, ComputedScalarTag, DeserializeArgs, Erasable, EvidenceVerdict, FullName,
+        MappingFunction, MappingTag, Message, MessageId, RemoteSignedTag, RuntimeError, ScalarFunction, ScalarTag,
+        SerializeArgs, SessionId, SpuriousError, Value, VerifiedValue,
     },
-    error::TraceableResult,
+    error::{Traceable, TraceableResult},
     flat_representation::{Action, OnError, Ruleset, RulesetState},
     graph_representation::{AnyNode, ArgNodes, OutputNode, PartyBuildData, PrivateInputs, PublicInputs},
     traits::{ExecutableProtocol, SessionParameters},
@@ -295,23 +295,6 @@ where
         Ok(self.make_report(SessionOutcome::Success(result)))
     }
 
-    fn finalize_with_stalled(self, tag: &CollectedTag) -> SessionReport<SP, P> {
-        self.make_report(SessionOutcome::Unfinishable(format!("Stalled at {tag}")))
-    }
-
-    /// Attempts to finalize the session.
-    pub fn try_finalize(self) -> SessionState<SP, P> {
-        let state = self.ruleset.state().clone();
-        match state {
-            RulesetState::InProgress => SessionState::InProgress(self),
-            RulesetState::ReachedOutput => SessionState::ReachedOutput(ReachedOutputSession(self)),
-            RulesetState::StalledAt(stalled_at) => SessionState::Stalled(StalledSession {
-                session: self,
-                stalled_at,
-            }),
-        }
-    }
-
     /// Terminates the session and returns the report containing the recorded failures of remote parties (if any).
     pub fn terminate(self) -> SessionReport<SP, P> {
         self.make_report(SessionOutcome::ManuallyTerminated)
@@ -475,16 +458,44 @@ where
     }
 
     /// Registers the result of an executed task.
-    pub fn add_result(&mut self, result: TaskResult<SP>) -> Result<(), TaskError<SP>> {
+    pub fn add_result(mut self, result: TaskResult<SP>) -> Result<SessionState<SP, P>, RuntimeError> {
+        let add_result = self.add_result_inner(result)?;
+        Ok(match add_result {
+            AddTaskResult::StateChanged => {
+                let state = self.ruleset.state().clone();
+                match state {
+                    RulesetState::InProgress => SessionState::InProgress(self),
+                    RulesetState::ReachedOutput => SessionState::ReachedOutput(ReachedOutputSession(self)),
+                    RulesetState::ImpossibleToCollect(tag) => {
+                        let report = self.make_report(SessionOutcome::ImpossibleToCollect(tag.to_string()));
+                        SessionState::Unfinishable(report)
+                    }
+                }
+            }
+            AddTaskResult::StateDidNotChange => SessionState::InProgress(self),
+            AddTaskResult::MessageAttributableError(error) => {
+                SessionState::InProgressWithMessageError { session: self, error }
+            }
+            AddTaskResult::SpuriousError(error) => {
+                let report = self.make_report(SessionOutcome::SpuriousError(error.to_string()));
+                SessionState::Unfinishable(report)
+            }
+        })
+    }
+
+    /// Registers the result of an executed task.
+    fn add_result_inner(&mut self, result: TaskResult<SP>) -> Result<AddTaskResult<SP>, RuntimeError> {
         match result.into_inner() {
-            TaskResultEnum::NoActionNeeded => {}
-            TaskResultEnum::RuntimeError(error) => return Err(TaskError::Runtime(error)),
-            TaskResultEnum::SpuriousError(error) => return Err(TaskError::Spurious(error)),
+            TaskResultEnum::NoActionNeeded => Ok(AddTaskResult::StateDidNotChange),
+            TaskResultEnum::RuntimeError(error) => Err(error.with_context("Task returned a runtime error")),
+            TaskResultEnum::SpuriousError(error) => Ok(AddTaskResult::SpuriousError(error)),
             TaskResultEnum::Sent { store_in, destination } => {
                 self.add_element(&store_in, &destination, Value::new(()))?;
+                Ok(AddTaskResult::StateChanged)
             }
             TaskResultEnum::ComputedScalar { store_in, result } => {
                 self.add_scalar(&store_in, result)?;
+                Ok(AddTaskResult::StateChanged)
             }
             TaskResultEnum::ComputedMappingElement {
                 store_in,
@@ -492,6 +503,7 @@ where
                 result,
             } => {
                 self.add_element(&store_in, &index, result)?;
+                Ok(AddTaskResult::StateChanged)
             }
             TaskResultEnum::SenderError {
                 store_in,
@@ -499,7 +511,10 @@ where
                 error,
                 on_error,
             } => match on_error {
-                OnError::Escalate => self.register_attributable_error(guilty_party, &store_in),
+                OnError::Escalate => {
+                    self.register_attributable_error(guilty_party, &store_in);
+                    Ok(AddTaskResult::StateChanged)
+                }
                 OnError::CollectEvidence(message_names) => {
                     let mut signed_values = Vec::new();
                     for name in message_names {
@@ -540,6 +555,7 @@ where
                         error,
                     ));
                     self.register_provable_error(Evidence::new(&self.data.id, &guilty_party, evidence));
+                    Ok(AddTaskResult::StateChanged)
                 }
             },
             TaskResultEnum::SenderErrorWithReveal {
@@ -548,7 +564,10 @@ where
                 error,
                 on_error,
             } => match on_error {
-                OnError::Escalate => self.register_attributable_error(guilty_party, &store_in),
+                OnError::Escalate => {
+                    self.register_attributable_error(guilty_party, &store_in);
+                    Ok(AddTaskResult::StateChanged)
+                }
                 OnError::CollectEvidence(message_names) => {
                     let mut signed_values = Vec::new();
                     for name in message_names {
@@ -589,6 +608,7 @@ where
                         error,
                     ));
                     self.register_provable_error(Evidence::new(&self.data.id, &guilty_party, evidence));
+                    Ok(AddTaskResult::StateChanged)
                 }
             },
             TaskResultEnum::ThirdPartyError { store_in, error } => {
@@ -596,6 +616,7 @@ where
                 let evidence =
                     EvidenceKind::ThirdPartyError(ThirdPartyErrorEvidence::new(&self.verifier, &store_in, error));
                 self.register_provable_error(Evidence::new(&self.data.id, &guilty_party, evidence));
+                Ok(AddTaskResult::StateChanged)
             }
             TaskResultEnum::Preprocessed {
                 store_in,
@@ -623,36 +644,34 @@ where
                             typed_received_value,
                         ));
                         self.register_provable_error(Evidence::new(&self.data.id, &source, evidence));
-                        return Ok(());
+                        return Ok(AddTaskResult::StateChanged);
                     }
 
                     // The message is a duplicate, we cannot do anything at this point.
                     // If the payload/metadata are invalid, the later checks will produce verifiable evidence.
                     // For now we can only report both message IDs that delivered these values,
                     // and let the user deal with it, if possible.
-                    return Err(TaskError::MessageAttributable(
-                        MessageAttributableError::DuplicateMessages(DuplicateMessagesError {
-                            first: typed_existing_value.message_id().clone(),
-                            second: typed_existing_value.message_id().clone(),
-                        }),
-                    ));
+                    let error = MessageAttributableError::DuplicateMessages(DuplicateMessagesError {
+                        first: typed_existing_value.message_id().clone(),
+                        second: typed_existing_value.message_id().clone(),
+                    });
+                    return Ok(AddTaskResult::MessageAttributableError(error));
                 }
 
                 self.add_element(&store_in, &source, value)?;
+                Ok(AddTaskResult::StateChanged)
             }
             TaskResultEnum::MessageError {
                 message_id,
                 description,
             } => {
-                return Err(TaskError::MessageAttributable(
-                    MessageAttributableError::InvalidMessage(InvalidMessageError {
-                        message_id,
-                        description,
-                    }),
-                ));
+                let error = MessageAttributableError::InvalidMessage(InvalidMessageError {
+                    message_id,
+                    description,
+                });
+                Ok(AddTaskResult::MessageAttributableError(error))
             }
         }
-        Ok(())
     }
 }
 
@@ -668,6 +687,7 @@ where
     /// Destroys the session and returns the report containing the output
     /// and recorded failures of remote parties (if any).
     pub fn finalize(self) -> Result<SessionReport<SP, P>, RuntimeError> {
+        // TODO: this should be infallible?
         self.0.finalize_with_success()
     }
 
@@ -693,42 +713,6 @@ where
     }
 }
 
-/// A wrapper for a session that is unfinishable.
-#[derive_where::derive_where(Debug)]
-pub struct StalledSession<SP: SessionParameters, P: ExecutableProtocol<SP>> {
-    session: Session<SP, P>,
-    stalled_at: CollectedTag,
-}
-
-impl<SP, P> StalledSession<SP, P>
-where
-    SP: SessionParameters,
-    P: ExecutableProtocol<SP>,
-{
-    /// Destroys the session and returns the report containing
-    /// recorded failures of remote parties (if any).
-    pub fn finalize(self) -> SessionReport<SP, P> {
-        self.session.finalize_with_stalled(&self.stalled_at)
-    }
-
-    /// Returns the contained session allowing to continue with the event loop.
-    ///
-    /// Can be used to accumulate more reports of malicious actions.
-    pub fn continue_execution(self) -> Session<SP, P> {
-        self.session
-    }
-}
-
-impl<SP, P> AsRef<Session<SP, P>> for StalledSession<SP, P>
-where
-    SP: SessionParameters,
-    P: ExecutableProtocol<SP>,
-{
-    fn as_ref(&self) -> &Session<SP, P> {
-        &self.session
-    }
-}
-
 /// Possible results of attempting to finalize a session.
 #[derive_where::derive_where(Debug)]
 pub enum SessionState<SP: SessionParameters, P: ExecutableProtocol<SP>> {
@@ -736,27 +720,20 @@ pub enum SessionState<SP: SessionParameters, P: ExecutableProtocol<SP>> {
     ///
     /// Continue working with the returned session object.
     InProgress(Session<SP, P>),
+    /// The session is in progress, but a message-attributable error was registered.
+    ///
+    /// Continue working with the returned session object,
+    /// and handle the error according to what your transport level allows.
+    InProgressWithMessageError {
+        /// The session in progress.
+        session: Session<SP, P>,
+        /// The message-attributable error.
+        error: MessageAttributableError<SP>,
+    },
     /// The session has reached the output.
     ReachedOutput(ReachedOutputSession<SP, P>),
     /// The session is unfinishable due to some nodes having been banned.
-    Stalled(StalledSession<SP, P>),
-}
-
-/// A possible error when registering a task's result.
-#[derive_where::derive_where(Debug)]
-pub enum TaskError<SP: SessionParameters> {
-    /// An internal error caused by the environment or a bug in the code.
-    Runtime(RuntimeError),
-    /// A random error that occurred during the protocol execution by no fault of a single party.
-    Spurious(SpuriousError),
-    /// An error that is attributable to a specific message, but not to a specific party.
-    MessageAttributable(MessageAttributableError<SP>),
-}
-
-impl<SP: SessionParameters> From<RuntimeError> for TaskError<SP> {
-    fn from(source: RuntimeError) -> Self {
-        Self::Runtime(source)
-    }
+    Unfinishable(SessionReport<SP, P>),
 }
 
 /// An error that is attributable to a specific message, but not to a specific party.
@@ -837,37 +814,32 @@ impl<SP: SessionParameters, P: ExecutableProtocol<SP>> SessionReport<SP, P> {
     /// Returns `true` if the session was terminated due to being unfinishable
     /// (enough nodes were banned to make some collection nodes impossible to trigger).
     pub fn is_unfinishable(&self) -> bool {
-        matches!(self.outcome, SessionOutcome::Unfinishable(..))
+        // TODO: change function name?
+        matches!(self.outcome, SessionOutcome::ImpossibleToCollect(..))
     }
 }
 
+/// Possible session outcomes.
 #[derive_where::derive_where(Debug, Clone)]
+#[derive(displaydoc::Display)]
 pub enum SessionOutcome<SP: SessionParameters, P: ExecutableProtocol<SP>> {
+    /// Reached the output successfully.
+    #[displaydoc("Success: {0:?}")]
     Success(P::Output),
+    /// Was terminated via [`Session::terminate`].
+    #[displaydoc("Manually terminated")]
     ManuallyTerminated,
-    Unfinishable(String),
+    /// Some collect nodes are impossible to finish due to some parties having been banned.
+    #[displaydoc("Impossible to collect: {0}")]
+    ImpossibleToCollect(String), // TODO: specify the number of banned parties or something?
+    /// A [`SpuriousError`] error occurred in one of the computations.
+    #[displaydoc("Spurious error: {0}")]
+    SpuriousError(String), // TODO: specify at which tag it occurred
 }
 
-// TODO: merge into SessionOutcome? Or allow termination where one can return RuntimeError AND all the evidences?
-/// A fatal error that can happen when executing a session.
-#[derive(Debug, Clone, displaydoc::Display)]
-pub enum SessionError {
-    /// See [`RuntimeError`].
-    #[displaydoc("{0}")]
-    Runtime(RuntimeError),
-    /// See [`SpuriousError`].
-    #[displaydoc("{0}")]
-    Spurious(SpuriousError),
-}
-
-impl From<RuntimeError> for SessionError {
-    fn from(source: RuntimeError) -> Self {
-        Self::Runtime(source)
-    }
-}
-
-impl From<SpuriousError> for SessionError {
-    fn from(source: SpuriousError) -> Self {
-        Self::Spurious(source)
-    }
+enum AddTaskResult<SP: SessionParameters> {
+    StateChanged,
+    StateDidNotChange,
+    MessageAttributableError(MessageAttributableError<SP>),
+    SpuriousError(SpuriousError),
 }

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -474,8 +474,8 @@ where
     pub fn add_result(&mut self, result: TaskResult<SP>) -> Result<(), TaskError<SP>> {
         match result.into_enum() {
             TaskResultEnum::NoActionNeeded => {}
-            TaskResultEnum::RuntimeError { error } => return Err(TaskError::Runtime(error)),
-            TaskResultEnum::SpuriousError { error } => return Err(TaskError::Spurious(error)),
+            TaskResultEnum::RuntimeError(error) => return Err(TaskError::Runtime(error)),
+            TaskResultEnum::SpuriousError(error) => return Err(TaskError::Spurious(error)),
             TaskResultEnum::Sent { store_in, destination } => {
                 self.add_element(&store_in, &destination, Value::new(()))?;
             }

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -31,8 +31,8 @@ use crate::dev::Replacement;
 use crate::{
     entities::{
         AnyTag, Args, AssociatedData, CollectedTag, ComputedScalarTag, DeserializeArgs, Erasable, EvidenceVerdict,
-        FullName, MappingFunction, MappingTag, Message, MessageId, RemoteSignedTag, RuntimeError, ScalarFunction,
-        ScalarTag, SerializeArgs, SessionId, SpuriousError, Value, VerifiedValue,
+        MappingFunction, MappingTag, Message, MessageId, RemoteSignedTag, RuntimeError, ScalarFunction, ScalarTag,
+        SerializeArgs, SessionId, SpuriousError, Value, VerifiedValue,
     },
     error::{Traceable, TraceableResult},
     flat_representation::{Action, OnError, Ruleset, RulesetState},
@@ -45,13 +45,6 @@ pub(crate) struct SessionData<SP: SessionParameters> {
     pub(crate) id: SessionId<SP>,
     pub(crate) participants: BTreeSet<SP::Verifier>,
     pub(crate) local_participants: BTreeSet<SP::Verifier>,
-    pub(crate) expected_messages: BTreeMap<FullName, BTreeSet<SP::Verifier>>,
-}
-
-impl<SP: SessionParameters> SessionData<SP> {
-    pub fn expected_senders(&self, message_name: &FullName) -> Option<BTreeSet<SP::Verifier>> {
-        self.expected_messages.get(message_name).cloned()
-    }
 }
 
 /// A state of a protocol being executed.
@@ -102,12 +95,10 @@ where
             .or_with_context(|| "Failed to build the ruleset".into())?;
         let storage = Storage::new();
 
-        let expected_messages = ruleset.expected_messages().clone();
         let data = Arc::new(SessionData {
             id,
             participants,
             local_participants,
-            expected_messages,
         });
         let mut session = Self {
             ruleset,
@@ -418,17 +409,14 @@ where
                     function,
                     index,
                     data,
-                    message_name,
                     serde_adapter,
+                    expected_senders,
                     on_error,
                 } => {
                     let value = self
                         .storage
                         .get_elem(&MappingTag::RemoteSigned(data), &index)
                         .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?;
-                    let expected_senders = self.data.expected_senders(&message_name).ok_or_else(|| {
-                        RuntimeError::expect(format!("{message_name} does not have expected senders"))
-                    })?;
                     let args = DeserializeArgs::new(&expected_senders, serde_adapter, value);
                     return Ok(Some(
                         DeserializeElementTask::new(store_in, function, index, args, on_error).into(),

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -24,7 +24,7 @@ use crate::{
     entities::{
         AnyTag, Args, AssociatedData, CollectedTag, ComputedScalarTag, DeserializeArgs, Erasable, EvidenceVerdict,
         FullName, MappingFunction, MappingTag, Message, MessageId, RemoteSignedTag, RuntimeError, ScalarFunction,
-        ScalarTag, SerializeArgs, SessionId, UnattributableError, Value, VerifiedValue,
+        ScalarTag, SerializeArgs, SessionId, SpuriousError, Value, VerifiedValue,
     },
     error::TraceableResult,
     flat_representation::{Action, OnError, Ruleset, RulesetState},
@@ -474,7 +474,8 @@ where
     pub fn add_result(&mut self, result: TaskResult<SP>) -> Result<(), TaskError<SP>> {
         match result.into_enum() {
             TaskResultEnum::Success => {}
-            TaskResultEnum::UnattributableError { error } => return Err(TaskError::Unattributable(error)),
+            TaskResultEnum::RuntimeError { error } => return Err(TaskError::Runtime(error)),
+            TaskResultEnum::SpuriousError { error } => return Err(TaskError::Spurious(error)),
             TaskResultEnum::Sent { store_in, destination } => {
                 self.add_element(&store_in, &destination, Value::new(()))?;
             }
@@ -743,15 +744,17 @@ pub enum SessionState<SP: SessionParameters, P: ExecutableProtocol<SP>> {
 /// A possible error when registering a task's result.
 #[derive_where::derive_where(Debug)]
 pub enum TaskError<SP: SessionParameters> {
-    /// An error that is not attributable to a specific party or message.
-    Unattributable(UnattributableError),
+    /// An internal error caused by the environment or a bug in the code.
+    Runtime(RuntimeError),
+    /// A random error that occurred during the protocol execution by no fault of a single party.
+    Spurious(SpuriousError),
     /// An error that is attributable to a specific message, but not to a specific party.
     MessageAttributable(MessageAttributableError<SP>),
 }
 
 impl<SP: SessionParameters> From<RuntimeError> for TaskError<SP> {
     fn from(source: RuntimeError) -> Self {
-        Self::Unattributable(source.into())
+        Self::Runtime(source)
     }
 }
 
@@ -842,4 +845,28 @@ pub enum SessionOutcome<SP: SessionParameters, P: ExecutableProtocol<SP>> {
     Success(P::Output),
     ManuallyTerminated,
     Unfinishable(String),
+}
+
+// TODO: merge into SessionOutcome? Or allow termination where one can return RuntimeError AND all the evidences?
+/// A fatal error that can happen when executing a session.
+#[derive(Debug, Clone, displaydoc::Display)]
+pub enum SessionError {
+    /// See [`RuntimeError`].
+    #[displaydoc("{0}")]
+    Runtime(RuntimeError),
+    /// See [`SpuriousError`].
+    #[displaydoc("{0}")]
+    Spurious(SpuriousError),
+}
+
+impl From<RuntimeError> for SessionError {
+    fn from(source: RuntimeError) -> Self {
+        Self::Runtime(source)
+    }
+}
+
+impl From<SpuriousError> for SessionError {
+    fn from(source: SpuriousError) -> Self {
+        Self::Spurious(source)
+    }
 }

--- a/ayatori/src/execution/storage.rs
+++ b/ayatori/src/execution/storage.rs
@@ -64,7 +64,9 @@ impl<Id: PartyId> Storage<Id> {
         let maybe_right = self.scalars.get(right).cloned();
         let result = match (maybe_left, maybe_right) {
             (None, None) => {
-                return Err(RuntimeError::expect(format!(
+                // If this error fires, it means that somehow the merge node is being executed
+                // without either of the paths leading to it having stored its results successfully.
+                return Err(RuntimeError::new(format!(
                     "Expected either {left} or {right} to be in storage"
                 )));
             }

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -21,277 +21,445 @@ use crate::{
 use crate::protocol_user_api::Session;
 
 #[derive_where::derive_where(Debug)]
-enum DeterministicTaskEnum<SP: SessionParameters> {
-    ScalarUnattributable {
-        store_in: ComputedScalarTag,
-        function: UnattributableScalarFunction<SP>,
-        args: Args<SP>,
-    },
-    ScalarUnattributableOptional {
-        store_in: ComputedScalarTag,
-        function: UnattributableOptionalScalarFunction<SP>,
-        args: Args<SP>,
-    },
-    MappingElementUnattributable {
-        store_in: ComputedMappingTag,
-        function: UnattributableMappingFunction<SP>,
-        source: SP::Verifier,
-        args: Args<SP>,
-    },
-    MappingElementSenderAttributable {
-        store_in: ComputedMappingTag,
-        function: SenderAttributableMappingFunction<SP>,
-        source: SP::Verifier,
-        args: Args<SP>,
-        on_error: OnError,
-    },
-    MappingElementSenderAttributableWithReveal {
-        store_in: ComputedMappingTag,
-        function: SenderAttributableWithRevealMappingFunction<SP>,
-        source: SP::Verifier,
-        args: Args<SP>,
-        on_error: OnError,
-    },
-    MappingElementThirdPartyAttributable {
-        store_in: ComputedMappingTag,
-        function: ThirdPartyAttributableMappingFunction<SP>,
-        source: SP::Verifier,
-        args: Args<SP>,
-    },
-    DeserializeElement {
-        store_in: ReceivedTag,
-        function: DeserializeFunction<SP>,
-        source: SP::Verifier,
-        args: DeserializeArgs<SP>,
-        on_error: OnError,
-    },
-    PreprocessMessage(PreprocessingTask<SP>),
+pub(crate) struct ScalarUnattributableTask<SP: SessionParameters> {
+    store_in: ComputedScalarTag,
+    function: UnattributableScalarFunction<SP>,
+    args: Args<SP>,
 }
 
-#[derive_where::derive_where(Debug)]
-pub struct DeterministicTask<SP: SessionParameters>(DeterministicTaskEnum<SP>);
+impl<SP: SessionParameters> ScalarUnattributableTask<SP> {
+    pub fn new(store_in: ComputedScalarTag, function: UnattributableScalarFunction<SP>, args: Args<SP>) -> Self {
+        Self {
+            store_in,
+            function,
+            args,
+        }
+    }
 
-impl<SP: SessionParameters> DeterministicTask<SP> {
     pub fn execute(self) -> TaskResult<SP> {
-        match self.0 {
-            DeterministicTaskEnum::ScalarUnattributable {
-                store_in,
-                function,
-                args,
-            } => {
-                let store_in = ScalarTag::Computed(store_in);
-                match function.call(&args) {
-                    Ok(result) => TaskResult(TaskResultEnum::ComputedScalar { store_in, result }),
-                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
-                }
-            }
-            DeterministicTaskEnum::ScalarUnattributableOptional {
-                store_in,
-                function,
-                args,
-            } => {
-                let store_in = ScalarTag::Computed(store_in);
-                match function.call(&args) {
-                    Ok(result) => TaskResult(result.map_or_else(
-                        || TaskResultEnum::NoActionNeeded,
-                        |value| TaskResultEnum::ComputedScalar {
-                            store_in,
-                            result: value,
-                        },
-                    )),
-                    Err(error) => TaskResult(TaskResultEnum::RuntimeError(error)),
-                }
-            }
-            DeterministicTaskEnum::MappingElementUnattributable {
-                store_in,
-                function,
-                source,
-                args,
-            } => {
-                let store_in = MappingTag::Computed(store_in);
-                match function.call(&source, &args) {
-                    Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
-                        store_in,
-                        source,
-                        result,
-                    }),
-                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
-                }
-            }
-            DeterministicTaskEnum::MappingElementSenderAttributable {
-                store_in,
-                function,
-                source,
-                args,
-                on_error,
-            } => {
-                let store_in = MappingTag::Computed(store_in);
-                match function.call(&source, &args) {
-                    Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
-                        store_in,
-                        source,
-                        result,
-                    }),
-                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
-                    Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
-                        store_in,
-                        guilty_party: source,
-                        error,
-                        on_error,
-                    }),
-                }
-            }
-            DeterministicTaskEnum::MappingElementSenderAttributableWithReveal {
-                store_in,
-                function,
-                source,
-                args,
-                on_error,
-            } => {
-                let store_in = MappingTag::Computed(store_in);
-                match function.call(&source, &args) {
-                    Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
-                        store_in,
-                        source,
-                        result,
-                    }),
-                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
-                    Err(MaybeAttributableError::Attributable(error)) => {
-                        TaskResult(TaskResultEnum::SenderErrorWithReveal {
-                            store_in,
-                            guilty_party: source,
-                            error,
-                            on_error,
-                        })
-                    }
-                }
-            }
-            DeterministicTaskEnum::MappingElementThirdPartyAttributable {
-                store_in,
-                function,
-                source,
-                args,
-            } => {
-                let store_in = MappingTag::Computed(store_in);
-                match function.call(&source, &args) {
-                    Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
-                        store_in,
-                        source,
-                        result,
-                    }),
-                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
-                    Err(MaybeAttributableError::Attributable(error)) => {
-                        TaskResult(TaskResultEnum::ThirdPartyError { store_in, error })
-                    }
-                }
-            }
-            DeterministicTaskEnum::DeserializeElement {
-                store_in,
-                function,
-                source,
-                args,
-                on_error,
-            } => {
-                let store_in = MappingTag::Received(store_in);
-                match function.call(&args) {
-                    Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
-                        store_in,
-                        source,
-                        result,
-                    }),
-                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
-                    Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
-                        store_in,
-                        guilty_party: source,
-                        error,
-                        on_error,
-                    }),
-                }
-            }
-            DeterministicTaskEnum::PreprocessMessage(task) => task.execute(),
+        let store_in = ScalarTag::Computed(self.store_in);
+        match self.function.call(&self.args) {
+            Ok(result) => TaskResult(TaskResultEnum::ComputedScalar { store_in, result }),
+            Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+            Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
         }
     }
 }
 
-#[derive_where::derive_where(Debug)]
-enum RandomizedTaskEnum<SP: SessionParameters> {
-    ScalarUnattributable {
-        store_in: ComputedScalarTag,
-        function: UnattributableScalarFunctionWithRng<SP>,
-        args: Args<SP>,
-    },
-    MappingElementUnattributable {
-        store_in: ComputedMappingTag,
-        function: UnattributableMappingFunctionWithRng<SP>,
-        source: SP::Verifier,
-        args: Args<SP>,
-    },
-    SerializeAndSignElement {
-        store_in: LocalSignedTag,
-        function: SerializeAndSignFunction<SP>,
-        source: SP::Verifier,
-        args: SerializeArgs<SP>,
-    },
+impl<SP: SessionParameters> From<ScalarUnattributableTask<SP>> for Task<SP> {
+    fn from(source: ScalarUnattributableTask<SP>) -> Self {
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::ScalarUnattributable(source)))
+    }
 }
 
 #[derive_where::derive_where(Debug)]
-pub struct RandomizedTask<SP: SessionParameters>(RandomizedTaskEnum<SP>);
+pub(crate) struct ScalarUnattributableOptionalTask<SP: SessionParameters> {
+    store_in: ComputedScalarTag,
+    function: UnattributableOptionalScalarFunction<SP>,
+    args: Args<SP>,
+}
 
-impl<SP: SessionParameters> RandomizedTask<SP> {
-    pub fn execute(self, rng: &mut impl CryptoRngCore) -> TaskResult<SP> {
-        match self.0 {
-            RandomizedTaskEnum::ScalarUnattributable {
+impl<SP: SessionParameters> ScalarUnattributableOptionalTask<SP> {
+    pub fn new(
+        store_in: ComputedScalarTag,
+        function: UnattributableOptionalScalarFunction<SP>,
+        args: Args<SP>,
+    ) -> Self {
+        Self {
+            store_in,
+            function,
+            args,
+        }
+    }
+
+    pub fn execute(self) -> TaskResult<SP> {
+        let store_in = ScalarTag::Computed(self.store_in);
+        match self.function.call(&self.args) {
+            Ok(result) => TaskResult(result.map_or_else(
+                || TaskResultEnum::NoActionNeeded,
+                |value| TaskResultEnum::ComputedScalar {
+                    store_in,
+                    result: value,
+                },
+            )),
+            Err(error) => TaskResult(TaskResultEnum::RuntimeError(error)),
+        }
+    }
+}
+
+impl<SP: SessionParameters> From<ScalarUnattributableOptionalTask<SP>> for Task<SP> {
+    fn from(source: ScalarUnattributableOptionalTask<SP>) -> Self {
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::ScalarUnattributableOptional(
+            source,
+        )))
+    }
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct ElementUnattributableTask<SP: SessionParameters> {
+    store_in: ComputedMappingTag,
+    function: UnattributableMappingFunction<SP>,
+    index: SP::Verifier,
+    args: Args<SP>,
+}
+
+impl<SP: SessionParameters> ElementUnattributableTask<SP> {
+    pub fn new(
+        store_in: ComputedMappingTag,
+        function: UnattributableMappingFunction<SP>,
+        index: SP::Verifier,
+        args: Args<SP>,
+    ) -> Self {
+        Self {
+            store_in,
+            function,
+            index,
+            args,
+        }
+    }
+
+    pub fn execute(self) -> TaskResult<SP> {
+        let store_in = MappingTag::Computed(self.store_in);
+        match self.function.call(&self.index, &self.args) {
+            Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
                 store_in,
-                function,
-                args,
-            } => {
-                let store_in = ScalarTag::Computed(store_in);
-                match function.call(rng, &args) {
-                    Ok(result) => TaskResult(TaskResultEnum::ComputedScalar { store_in, result }),
-                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
-                }
-            }
-            RandomizedTaskEnum::MappingElementUnattributable {
+                index: self.index,
+                result,
+            }),
+            Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+            Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+        }
+    }
+}
+
+impl<SP: SessionParameters> From<ElementUnattributableTask<SP>> for Task<SP> {
+    fn from(source: ElementUnattributableTask<SP>) -> Self {
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::ElementUnattributable(source)))
+    }
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct ElementSenderAttributableTask<SP: SessionParameters> {
+    store_in: ComputedMappingTag,
+    function: SenderAttributableMappingFunction<SP>,
+    index: SP::Verifier,
+    args: Args<SP>,
+    on_error: OnError,
+}
+
+impl<SP: SessionParameters> ElementSenderAttributableTask<SP> {
+    pub fn new(
+        store_in: ComputedMappingTag,
+        function: SenderAttributableMappingFunction<SP>,
+        index: SP::Verifier,
+        args: Args<SP>,
+        on_error: OnError,
+    ) -> Self {
+        Self {
+            store_in,
+            function,
+            index,
+            args,
+            on_error,
+        }
+    }
+
+    pub fn execute(self) -> TaskResult<SP> {
+        let store_in = MappingTag::Computed(self.store_in);
+        match self.function.call(&self.index, &self.args) {
+            Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
                 store_in,
-                function,
-                source,
-                args,
-            } => {
-                let store_in = MappingTag::Computed(store_in);
-                match function.call(rng, &source, &args) {
-                    Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
-                        store_in,
-                        source,
-                        result,
-                    }),
-                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
-                }
-            }
-            RandomizedTaskEnum::SerializeAndSignElement {
+                index: self.index,
+                result,
+            }),
+            Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+            Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
                 store_in,
-                function,
-                source,
-                args,
-            } => {
-                let store_in = MappingTag::LocalSigned(store_in);
-                match function.call(rng, &source, &args) {
-                    Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
-                        store_in,
-                        source,
-                        result,
-                    }),
-                    Err(error) => TaskResult(TaskResultEnum::RuntimeError(error)),
-                }
+                guilty_party: self.index,
+                error,
+                on_error: self.on_error,
+            }),
+        }
+    }
+}
+
+impl<SP: SessionParameters> From<ElementSenderAttributableTask<SP>> for Task<SP> {
+    fn from(source: ElementSenderAttributableTask<SP>) -> Self {
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::ElementSenderAttributable(
+            source,
+        )))
+    }
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct ElementSenderAttributableWithRevealTask<SP: SessionParameters> {
+    store_in: ComputedMappingTag,
+    function: SenderAttributableWithRevealMappingFunction<SP>,
+    index: SP::Verifier,
+    args: Args<SP>,
+    on_error: OnError,
+}
+
+impl<SP: SessionParameters> ElementSenderAttributableWithRevealTask<SP> {
+    pub fn new(
+        store_in: ComputedMappingTag,
+        function: SenderAttributableWithRevealMappingFunction<SP>,
+        index: SP::Verifier,
+        args: Args<SP>,
+        on_error: OnError,
+    ) -> Self {
+        Self {
+            store_in,
+            function,
+            index,
+            args,
+            on_error,
+        }
+    }
+
+    pub fn execute(self) -> TaskResult<SP> {
+        let store_in = MappingTag::Computed(self.store_in);
+        match self.function.call(&self.index, &self.args) {
+            Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
+                store_in,
+                index: self.index,
+                result,
+            }),
+            Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+            Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderErrorWithReveal {
+                store_in,
+                guilty_party: self.index,
+                error,
+                on_error: self.on_error,
+            }),
+        }
+    }
+}
+
+impl<SP: SessionParameters> From<ElementSenderAttributableWithRevealTask<SP>> for Task<SP> {
+    fn from(source: ElementSenderAttributableWithRevealTask<SP>) -> Self {
+        Self::Deterministic(DeterministicTask(
+            DeterministicTaskEnum::ElementSenderAttributableWithReveal(source),
+        ))
+    }
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct ElementThirdPartyAttributableTask<SP: SessionParameters> {
+    store_in: ComputedMappingTag,
+    function: ThirdPartyAttributableMappingFunction<SP>,
+    index: SP::Verifier,
+    args: Args<SP>,
+}
+
+impl<SP: SessionParameters> ElementThirdPartyAttributableTask<SP> {
+    pub fn new(
+        store_in: ComputedMappingTag,
+        function: ThirdPartyAttributableMappingFunction<SP>,
+        index: SP::Verifier,
+        args: Args<SP>,
+    ) -> Self {
+        Self {
+            store_in,
+            function,
+            index,
+            args,
+        }
+    }
+
+    pub fn execute(self) -> TaskResult<SP> {
+        let store_in = MappingTag::Computed(self.store_in);
+        match self.function.call(&self.index, &self.args) {
+            Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
+                store_in,
+                index: self.index,
+                result,
+            }),
+            Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+            Err(MaybeAttributableError::Attributable(error)) => {
+                TaskResult(TaskResultEnum::ThirdPartyError { store_in, error })
             }
         }
+    }
+}
+
+impl<SP: SessionParameters> From<ElementThirdPartyAttributableTask<SP>> for Task<SP> {
+    fn from(source: ElementThirdPartyAttributableTask<SP>) -> Self {
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::ElementThirdPartyAttributable(
+            source,
+        )))
+    }
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct DeserializeElementTask<SP: SessionParameters> {
+    store_in: ReceivedTag,
+    function: DeserializeFunction<SP>,
+    index: SP::Verifier,
+    args: DeserializeArgs<SP>,
+    on_error: OnError,
+}
+
+impl<SP: SessionParameters> DeserializeElementTask<SP> {
+    pub fn new(
+        store_in: ReceivedTag,
+        function: DeserializeFunction<SP>,
+        index: SP::Verifier,
+        args: DeserializeArgs<SP>,
+        on_error: OnError,
+    ) -> Self {
+        Self {
+            store_in,
+            function,
+            index,
+            args,
+            on_error,
+        }
+    }
+
+    pub fn execute(self) -> TaskResult<SP> {
+        let store_in = MappingTag::Received(self.store_in);
+        match self.function.call(&self.args) {
+            Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
+                store_in,
+                index: self.index,
+                result,
+            }),
+            Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+            Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
+                store_in,
+                guilty_party: self.index,
+                error,
+                on_error: self.on_error,
+            }),
+        }
+    }
+}
+
+impl<SP: SessionParameters> From<DeserializeElementTask<SP>> for Task<SP> {
+    fn from(source: DeserializeElementTask<SP>) -> Self {
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::DeserializeElement(source)))
+    }
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct RngScalarUnattributableTask<SP: SessionParameters> {
+    store_in: ComputedScalarTag,
+    function: UnattributableScalarFunctionWithRng<SP>,
+    args: Args<SP>,
+}
+
+impl<SP: SessionParameters> RngScalarUnattributableTask<SP> {
+    pub fn new(store_in: ComputedScalarTag, function: UnattributableScalarFunctionWithRng<SP>, args: Args<SP>) -> Self {
+        Self {
+            store_in,
+            function,
+            args,
+        }
+    }
+
+    pub fn execute(self, rng: &mut impl CryptoRngCore) -> TaskResult<SP> {
+        let store_in = ScalarTag::Computed(self.store_in);
+        match self.function.call(rng, &self.args) {
+            Ok(result) => TaskResult(TaskResultEnum::ComputedScalar { store_in, result }),
+            Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+            Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+        }
+    }
+}
+
+impl<SP: SessionParameters> From<RngScalarUnattributableTask<SP>> for Task<SP> {
+    fn from(source: RngScalarUnattributableTask<SP>) -> Self {
+        Self::Randomized(RandomizedTask(RandomizedTaskEnum::ScalarUnattributable(source)))
+    }
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct RngElementUnattributableTask<SP: SessionParameters> {
+    store_in: ComputedMappingTag,
+    function: UnattributableMappingFunctionWithRng<SP>,
+    index: SP::Verifier,
+    args: Args<SP>,
+}
+
+impl<SP: SessionParameters> RngElementUnattributableTask<SP> {
+    pub fn new(
+        store_in: ComputedMappingTag,
+        function: UnattributableMappingFunctionWithRng<SP>,
+        index: SP::Verifier,
+        args: Args<SP>,
+    ) -> Self {
+        Self {
+            store_in,
+            function,
+            index,
+            args,
+        }
+    }
+
+    pub fn execute(self, rng: &mut impl CryptoRngCore) -> TaskResult<SP> {
+        let store_in = MappingTag::Computed(self.store_in);
+        match self.function.call(rng, &self.index, &self.args) {
+            Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
+                store_in,
+                index: self.index,
+                result,
+            }),
+            Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+            Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+        }
+    }
+}
+
+impl<SP: SessionParameters> From<RngElementUnattributableTask<SP>> for Task<SP> {
+    fn from(source: RngElementUnattributableTask<SP>) -> Self {
+        Self::Randomized(RandomizedTask(RandomizedTaskEnum::ElementUnattributable(source)))
+    }
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct SerializeAndSignElementTask<SP: SessionParameters> {
+    store_in: LocalSignedTag,
+    function: SerializeAndSignFunction<SP>,
+    index: SP::Verifier,
+    args: SerializeArgs<SP>,
+}
+
+impl<SP: SessionParameters> SerializeAndSignElementTask<SP> {
+    pub fn new(
+        store_in: LocalSignedTag,
+        function: SerializeAndSignFunction<SP>,
+        index: SP::Verifier,
+        args: SerializeArgs<SP>,
+    ) -> Self {
+        Self {
+            store_in,
+            function,
+            index,
+            args,
+        }
+    }
+
+    pub fn execute(self, rng: &mut impl CryptoRngCore) -> TaskResult<SP> {
+        let store_in = MappingTag::LocalSigned(self.store_in);
+        match self.function.call(rng, &self.index, &self.args) {
+            Ok(result) => TaskResult(TaskResultEnum::ComputedMappingElement {
+                store_in,
+                index: self.index,
+                result,
+            }),
+            Err(error) => TaskResult(TaskResultEnum::RuntimeError(error)),
+        }
+    }
+}
+
+impl<SP: SessionParameters> From<SerializeAndSignElementTask<SP>> for Task<SP> {
+    fn from(source: SerializeAndSignElementTask<SP>) -> Self {
+        Self::Randomized(RandomizedTask(RandomizedTaskEnum::SerializeAndSignElement(source)))
     }
 }
 
@@ -303,6 +471,14 @@ pub struct SendTask<SP: SessionParameters> {
 }
 
 impl<SP: SessionParameters> SendTask<SP> {
+    pub(crate) fn new(store_in: SentTag, destination: SP::Verifier, signed_value: Value) -> Self {
+        Self {
+            store_in,
+            destination,
+            signed_value,
+        }
+    }
+
     pub fn execute(self) -> (Option<Message<SP>>, TaskResult<SP>) {
         let signed_value = match self.signed_value.downcast::<SignedValue<SP>>() {
             Ok(value) => value,
@@ -318,244 +494,21 @@ impl<SP: SessionParameters> SendTask<SP> {
     }
 }
 
-/// A session task to be executed.
-#[derive_where::derive_where(Debug)]
-pub enum Task<SP: SessionParameters> {
-    /// Send an outgoing message.
-    Send(SendTask<SP>),
-    /// Perform a dererministic computation.
-    Deterministic(DeterministicTask<SP>),
-    /// Perform a computation that needs access to an RNG.
-    Randomized(RandomizedTask<SP>),
-}
-
-impl<SP: SessionParameters> Task<SP> {
-    pub(crate) fn preprocess_message(task: PreprocessingTask<SP>) -> Self {
-        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::PreprocessMessage(task)))
-    }
-
-    pub(crate) fn direct_message(store_in: SentTag, destination: SP::Verifier, signed_value: Value) -> Self {
-        Self::Send(SendTask {
-            store_in,
-            destination,
-            signed_value,
-        })
-    }
-
-    pub(crate) fn compute_scalar_unattributable(
-        store_in: ComputedScalarTag,
-        function: UnattributableScalarFunction<SP>,
-        args: Args<SP>,
-    ) -> Self {
-        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::ScalarUnattributable {
-            store_in,
-            function,
-            args,
-        }))
-    }
-
-    pub(crate) fn compute_scalar_unattributable_optional(
-        store_in: ComputedScalarTag,
-        function: UnattributableOptionalScalarFunction<SP>,
-        args: Args<SP>,
-    ) -> Self {
-        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::ScalarUnattributableOptional {
-            store_in,
-            function,
-            args,
-        }))
-    }
-
-    pub(crate) fn compute_scalar_unattributable_with_rng(
-        store_in: ComputedScalarTag,
-        function: UnattributableScalarFunctionWithRng<SP>,
-        args: Args<SP>,
-    ) -> Self {
-        Self::Randomized(RandomizedTask(RandomizedTaskEnum::ScalarUnattributable {
-            store_in,
-            function,
-            args,
-        }))
-    }
-
-    pub(crate) fn compute_mapping_elem_unattributable(
-        store_in: ComputedMappingTag,
-        source: SP::Verifier,
-        function: UnattributableMappingFunction<SP>,
-        args: Args<SP>,
-    ) -> Self {
-        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::MappingElementUnattributable {
-            store_in,
-            source,
-            function,
-            args,
-        }))
-    }
-
-    pub(crate) fn compute_mapping_elem_unattributable_with_rng(
-        store_in: ComputedMappingTag,
-        source: SP::Verifier,
-        function: UnattributableMappingFunctionWithRng<SP>,
-        args: Args<SP>,
-    ) -> Self {
-        Self::Randomized(RandomizedTask(RandomizedTaskEnum::MappingElementUnattributable {
-            store_in,
-            source,
-            function,
-            args,
-        }))
-    }
-
-    pub(crate) fn compute_serialize_and_sign_elem(
-        store_in: LocalSignedTag,
-        source: SP::Verifier,
-        function: SerializeAndSignFunction<SP>,
-        args: SerializeArgs<SP>,
-    ) -> Self {
-        Self::Randomized(RandomizedTask(RandomizedTaskEnum::SerializeAndSignElement {
-            store_in,
-            source,
-            function,
-            args,
-        }))
-    }
-
-    pub(crate) fn compute_deserialize_elem(
-        store_in: ReceivedTag,
-        source: SP::Verifier,
-        function: DeserializeFunction<SP>,
-        args: DeserializeArgs<SP>,
-        on_error: OnError,
-    ) -> Self {
-        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::DeserializeElement {
-            store_in,
-            source,
-            function,
-            args,
-            on_error,
-        }))
-    }
-
-    pub(crate) fn compute_mapping_elem_sender_attributable(
-        store_in: ComputedMappingTag,
-        source: SP::Verifier,
-        function: SenderAttributableMappingFunction<SP>,
-        args: Args<SP>,
-        on_error: OnError,
-    ) -> Self {
-        Self::Deterministic(DeterministicTask(
-            DeterministicTaskEnum::MappingElementSenderAttributable {
-                store_in,
-                source,
-                function,
-                args,
-                on_error,
-            },
-        ))
-    }
-
-    pub(crate) fn compute_mapping_elem_sender_attributable_with_reveal(
-        store_in: ComputedMappingTag,
-        source: SP::Verifier,
-        function: SenderAttributableWithRevealMappingFunction<SP>,
-        args: Args<SP>,
-        on_error: OnError,
-    ) -> Self {
-        Self::Deterministic(DeterministicTask(
-            DeterministicTaskEnum::MappingElementSenderAttributableWithReveal {
-                store_in,
-                source,
-                function,
-                args,
-                on_error,
-            },
-        ))
-    }
-
-    pub(crate) fn compute_mapping_elem_third_party_attributable(
-        store_in: ComputedMappingTag,
-        source: SP::Verifier,
-        function: ThirdPartyAttributableMappingFunction<SP>,
-        args: Args<SP>,
-    ) -> Self {
-        Self::Deterministic(DeterministicTask(
-            DeterministicTaskEnum::MappingElementThirdPartyAttributable {
-                store_in,
-                source,
-                function,
-                args,
-            },
-        ))
+impl<SP: SessionParameters> From<SendTask<SP>> for Task<SP> {
+    fn from(source: SendTask<SP>) -> Self {
+        Self::Send(source)
     }
 }
 
 #[derive_where::derive_where(Debug)]
-pub struct TaskResult<SP: SessionParameters>(TaskResultEnum<SP>);
-
-impl<SP: SessionParameters> TaskResult<SP> {
-    pub(crate) fn into_enum(self) -> TaskResultEnum<SP> {
-        self.0
-    }
-}
-
-#[derive_where::derive_where(Debug)]
-pub(crate) enum TaskResultEnum<SP: SessionParameters> {
-    NoActionNeeded,
-    Sent {
-        store_in: MappingTag,
-        destination: SP::Verifier,
-    },
-    ComputedScalar {
-        store_in: ScalarTag,
-        result: Value,
-    },
-    ComputedMappingElement {
-        store_in: MappingTag,
-        source: SP::Verifier,
-        result: Value,
-    },
-    Preprocessed {
-        store_in: MappingTag,
-        source: SP::Verifier,
-        value: Value,
-    },
-    RuntimeError(RuntimeError),
-    SpuriousError(SpuriousError),
-    SenderError {
-        store_in: MappingTag,
-        guilty_party: SP::Verifier,
-        error: SenderError,
-        on_error: OnError,
-    },
-    SenderErrorWithReveal {
-        store_in: MappingTag,
-        guilty_party: SP::Verifier,
-        error: SenderErrorWithReveal<SP>,
-        on_error: OnError,
-    },
-    ThirdPartyError {
-        store_in: MappingTag,
-        error: ThirdPartyError<SP>,
-    },
-    MessageError {
-        message_id: MessageId<SP>,
-        description: String,
-    },
-}
-
-#[derive_where::derive_where(Debug)]
-pub struct PreprocessingTask<SP: SessionParameters> {
+pub(crate) struct PreprocessMessageTask<SP: SessionParameters> {
     session_data: Arc<SessionData<SP>>,
     message_id: MessageId<SP>,
     signed_value: SignedValue<SP>,
 }
 
-impl<SP: SessionParameters> PreprocessingTask<SP> {
-    pub(crate) fn new(
-        session_data: &Arc<SessionData<SP>>,
-        message_id: MessageId<SP>,
-        signed_value: SignedValue<SP>,
-    ) -> Self {
+impl<SP: SessionParameters> PreprocessMessageTask<SP> {
+    pub fn new(session_data: &Arc<SessionData<SP>>, message_id: MessageId<SP>, signed_value: SignedValue<SP>) -> Self {
         Self {
             session_data: session_data.clone(),
             message_id,
@@ -628,4 +581,125 @@ impl<SP: SessionParameters> PreprocessingTask<SP> {
             value,
         })
     }
+}
+
+impl<SP: SessionParameters> From<PreprocessMessageTask<SP>> for Task<SP> {
+    fn from(source: PreprocessMessageTask<SP>) -> Self {
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::PreprocessMessage(source)))
+    }
+}
+
+#[derive_where::derive_where(Debug)]
+enum DeterministicTaskEnum<SP: SessionParameters> {
+    ScalarUnattributable(ScalarUnattributableTask<SP>),
+    ScalarUnattributableOptional(ScalarUnattributableOptionalTask<SP>),
+    ElementUnattributable(ElementUnattributableTask<SP>),
+    ElementSenderAttributable(ElementSenderAttributableTask<SP>),
+    ElementSenderAttributableWithReveal(ElementSenderAttributableWithRevealTask<SP>),
+    ElementThirdPartyAttributable(ElementThirdPartyAttributableTask<SP>),
+    DeserializeElement(DeserializeElementTask<SP>),
+    PreprocessMessage(PreprocessMessageTask<SP>),
+}
+
+#[derive_where::derive_where(Debug)]
+pub struct DeterministicTask<SP: SessionParameters>(DeterministicTaskEnum<SP>);
+
+impl<SP: SessionParameters> DeterministicTask<SP> {
+    pub fn execute(self) -> TaskResult<SP> {
+        match self.0 {
+            DeterministicTaskEnum::ScalarUnattributable(task) => task.execute(),
+            DeterministicTaskEnum::ScalarUnattributableOptional(task) => task.execute(),
+            DeterministicTaskEnum::ElementUnattributable(task) => task.execute(),
+            DeterministicTaskEnum::ElementSenderAttributable(task) => task.execute(),
+            DeterministicTaskEnum::ElementSenderAttributableWithReveal(task) => task.execute(),
+            DeterministicTaskEnum::ElementThirdPartyAttributable(task) => task.execute(),
+            DeterministicTaskEnum::DeserializeElement(task) => task.execute(),
+            DeterministicTaskEnum::PreprocessMessage(task) => task.execute(),
+        }
+    }
+}
+
+#[derive_where::derive_where(Debug)]
+enum RandomizedTaskEnum<SP: SessionParameters> {
+    ScalarUnattributable(RngScalarUnattributableTask<SP>),
+    ElementUnattributable(RngElementUnattributableTask<SP>),
+    SerializeAndSignElement(SerializeAndSignElementTask<SP>),
+}
+
+#[derive_where::derive_where(Debug)]
+pub struct RandomizedTask<SP: SessionParameters>(RandomizedTaskEnum<SP>);
+
+impl<SP: SessionParameters> RandomizedTask<SP> {
+    pub fn execute(self, rng: &mut impl CryptoRngCore) -> TaskResult<SP> {
+        match self.0 {
+            RandomizedTaskEnum::ScalarUnattributable(task) => task.execute(rng),
+            RandomizedTaskEnum::ElementUnattributable(task) => task.execute(rng),
+            RandomizedTaskEnum::SerializeAndSignElement(task) => task.execute(rng),
+        }
+    }
+}
+
+/// A session task to be executed.
+#[derive_where::derive_where(Debug)]
+pub enum Task<SP: SessionParameters> {
+    /// Send an outgoing message.
+    Send(SendTask<SP>),
+    /// Perform a dererministic computation.
+    Deterministic(DeterministicTask<SP>),
+    /// Perform a computation that needs access to an RNG.
+    Randomized(RandomizedTask<SP>),
+}
+
+#[derive_where::derive_where(Debug)]
+pub struct TaskResult<SP: SessionParameters>(TaskResultEnum<SP>);
+
+impl<SP: SessionParameters> TaskResult<SP> {
+    pub(crate) fn into_inner(self) -> TaskResultEnum<SP> {
+        self.0
+    }
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) enum TaskResultEnum<SP: SessionParameters> {
+    NoActionNeeded,
+    Sent {
+        store_in: MappingTag,
+        destination: SP::Verifier,
+    },
+    ComputedScalar {
+        store_in: ScalarTag,
+        result: Value,
+    },
+    ComputedMappingElement {
+        store_in: MappingTag,
+        index: SP::Verifier,
+        result: Value,
+    },
+    Preprocessed {
+        store_in: MappingTag,
+        source: SP::Verifier,
+        value: Value,
+    },
+    RuntimeError(RuntimeError),
+    SpuriousError(SpuriousError),
+    SenderError {
+        store_in: MappingTag,
+        guilty_party: SP::Verifier,
+        error: SenderError,
+        on_error: OnError,
+    },
+    SenderErrorWithReveal {
+        store_in: MappingTag,
+        guilty_party: SP::Verifier,
+        error: SenderErrorWithReveal<SP>,
+        on_error: OnError,
+    },
+    ThirdPartyError {
+        store_in: MappingTag,
+        error: ThirdPartyError<SP>,
+    },
+    MessageError {
+        message_id: MessageId<SP>,
+        description: String,
+    },
 }

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -65,9 +65,7 @@ enum ComputeTaskEnum<SP: SessionParameters> {
         args: DeserializeArgs<SP>,
         on_error: OnError,
     },
-    PreprocessMessage {
-        task: PreprocessingTask<SP>,
-    },
+    PreprocessMessage(PreprocessingTask<SP>),
 }
 
 #[derive_where::derive_where(Debug)]
@@ -84,8 +82,8 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                 let store_in = ScalarTag::Computed(store_in);
                 match function.call(&args) {
                     Ok(result) => TaskResult(TaskResultEnum::ComputedScalar { store_in, result }),
-                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
-                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
+                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
                 }
             }
             ComputeTaskEnum::ScalarUnattributableOptional {
@@ -102,7 +100,7 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                             result: value,
                         },
                     )),
-                    Err(error) => TaskResult(TaskResultEnum::RuntimeError { error }),
+                    Err(error) => TaskResult(TaskResultEnum::RuntimeError(error)),
                 }
             }
             ComputeTaskEnum::MappingElementUnattributable {
@@ -118,8 +116,8 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
-                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
+                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
                 }
             }
             ComputeTaskEnum::MappingElementSenderAttributable {
@@ -136,8 +134,8 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
-                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
+                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
                     Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
                         store_in,
                         guilty_party: source,
@@ -160,8 +158,8 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
-                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
+                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
                     Err(MaybeAttributableError::Attributable(error)) => {
                         TaskResult(TaskResultEnum::SenderErrorWithReveal {
                             store_in,
@@ -185,8 +183,8 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
-                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
+                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
                     Err(MaybeAttributableError::Attributable(error)) => {
                         TaskResult(TaskResultEnum::ThirdPartyError { store_in, error })
                     }
@@ -206,8 +204,8 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
-                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
+                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
                     Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
                         store_in,
                         guilty_party: source,
@@ -216,7 +214,7 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                     }),
                 }
             }
-            ComputeTaskEnum::PreprocessMessage { task } => task.execute(),
+            ComputeTaskEnum::PreprocessMessage(task) => task.execute(),
         }
     }
 }
@@ -256,8 +254,8 @@ impl<SP: SessionParameters> ComputeWithRngTask<SP> {
                 let store_in = ScalarTag::Computed(store_in);
                 match function.call(rng, &args) {
                     Ok(result) => TaskResult(TaskResultEnum::ComputedScalar { store_in, result }),
-                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
-                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
+                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
                 }
             }
             ComputeWithRngTaskEnum::MappingElementUnattributable {
@@ -273,8 +271,8 @@ impl<SP: SessionParameters> ComputeWithRngTask<SP> {
                         source,
                         result,
                     }),
-                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
-                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
+                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
+                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
                 }
             }
             ComputeWithRngTaskEnum::SerializeAndSignElement {
@@ -290,7 +288,7 @@ impl<SP: SessionParameters> ComputeWithRngTask<SP> {
                         source,
                         result,
                     }),
-                    Err(error) => TaskResult(TaskResultEnum::RuntimeError { error }),
+                    Err(error) => TaskResult(TaskResultEnum::RuntimeError(error)),
                 }
             }
         }
@@ -308,7 +306,7 @@ impl<SP: SessionParameters> SendTask<SP> {
     pub fn execute(self) -> (Option<Message<SP>>, TaskResult<SP>) {
         let signed_value = match self.signed_value.downcast::<SignedValue<SP>>() {
             Ok(value) => value,
-            Err(error) => return (None, TaskResult(TaskResultEnum::RuntimeError { error })),
+            Err(error) => return (None, TaskResult(TaskResultEnum::RuntimeError(error))),
         };
         let signed_values = vec![signed_value];
         let message = Message::new(self.destination.clone(), signed_values);
@@ -333,7 +331,7 @@ pub enum Task<SP: SessionParameters> {
 
 impl<SP: SessionParameters> Task<SP> {
     pub(crate) fn preprocess_message(task: PreprocessingTask<SP>) -> Self {
-        Self::Compute(ComputeTask(ComputeTaskEnum::PreprocessMessage { task }))
+        Self::Compute(ComputeTask(ComputeTaskEnum::PreprocessMessage(task)))
     }
 
     pub(crate) fn direct_message(store_in: SentTag, destination: SP::Verifier, signed_value: Value) -> Self {
@@ -519,12 +517,8 @@ pub(crate) enum TaskResultEnum<SP: SessionParameters> {
         source: SP::Verifier,
         value: Value,
     },
-    RuntimeError {
-        error: RuntimeError,
-    },
-    SpuriousError {
-        error: SpuriousError,
-    },
+    RuntimeError(RuntimeError),
+    SpuriousError(SpuriousError),
     SenderError {
         store_in: MappingTag,
         guilty_party: SP::Verifier,
@@ -614,7 +608,7 @@ impl<SP: SessionParameters> PreprocessingTask<SP> {
         // Verify the value signature.
         let verified_value = match self.signed_value.verify(&self.message_id) {
             Ok(value) => value,
-            Err(VerificationError::Runtime(error)) => return TaskResult(TaskResultEnum::RuntimeError { error }),
+            Err(VerificationError::Runtime(error)) => return TaskResult(TaskResultEnum::RuntimeError(error)),
             Err(VerificationError::SignatureMismatch) => {
                 return TaskResult(TaskResultEnum::MessageError {
                     message_id: self.message_id.clone(),

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -179,10 +179,6 @@ impl<SP: SessionParameters> ElementSenderAttributableTask<SP> {
                 result,
             }),
             Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError {
-                store_in: AnyTag::Mapping(store_in),
-                error,
-            }),
             Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
                 store_in,
                 guilty_party: self.index,
@@ -236,10 +232,6 @@ impl<SP: SessionParameters> ElementSenderAttributableWithRevealTask<SP> {
                 result,
             }),
             Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError {
-                store_in: AnyTag::Mapping(store_in),
-                error,
-            }),
             Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderErrorWithReveal {
                 store_in,
                 guilty_party: self.index,
@@ -290,10 +282,6 @@ impl<SP: SessionParameters> ElementThirdPartyAttributableTask<SP> {
                 result,
             }),
             Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError {
-                store_in: AnyTag::Mapping(store_in),
-                error,
-            }),
             Err(MaybeAttributableError::Attributable(error)) => {
                 TaskResult(TaskResultEnum::ThirdPartyError { store_in, error })
             }
@@ -344,10 +332,6 @@ impl<SP: SessionParameters> DeserializeElementTask<SP> {
                 result,
             }),
             Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError {
-                store_in: AnyTag::Mapping(store_in),
-                error,
-            }),
             Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
                 store_in,
                 guilty_party: self.index,

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -6,10 +6,9 @@ use super::session::SessionData;
 use crate::{
     entities::{
         Args, ComputedMappingTag, ComputedScalarTag, DeserializeArgs, DeserializeFunction, LocalSignedTag, MappingTag,
-        Message, MessageId, ReceivedTag, RemoteSignedTag, RuntimeError, ScalarTag, SenderAttributableError,
-        SenderAttributableErrorWithReveal, SenderAttributableMappingFunction,
-        SenderAttributableWithRevealMappingFunction, SenderError, SenderErrorWithReveal, SentTag,
-        SerializeAndSignFunction, SerializeArgs, SignedValue, SpuriousError, ThirdPartyAttributableError,
+        MaybeAttributableError, Message, MessageId, ReceivedTag, RemoteSignedTag, RuntimeError, ScalarTag,
+        SenderAttributableMappingFunction, SenderAttributableWithRevealMappingFunction, SenderError,
+        SenderErrorWithReveal, SentTag, SerializeAndSignFunction, SerializeArgs, SignedValue, SpuriousError,
         ThirdPartyAttributableMappingFunction, ThirdPartyError, UnattributableError, UnattributableMappingFunction,
         UnattributableMappingFunctionWithRng, UnattributableOptionalScalarFunction, UnattributableScalarFunction,
         UnattributableScalarFunctionWithRng, Value, VerificationError,
@@ -137,11 +136,9 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(SenderAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
-                    Err(SenderAttributableError::Spurious(error)) => {
-                        TaskResult(TaskResultEnum::SpuriousError { error })
-                    }
-                    Err(SenderAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
+                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
+                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
+                    Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
                         store_in,
                         guilty_party: source,
                         error,
@@ -163,13 +160,9 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(SenderAttributableErrorWithReveal::Runtime(error)) => {
-                        TaskResult(TaskResultEnum::RuntimeError { error })
-                    }
-                    Err(SenderAttributableErrorWithReveal::Spurious(error)) => {
-                        TaskResult(TaskResultEnum::SpuriousError { error })
-                    }
-                    Err(SenderAttributableErrorWithReveal::Attributable(error)) => {
+                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
+                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
+                    Err(MaybeAttributableError::Attributable(error)) => {
                         TaskResult(TaskResultEnum::SenderErrorWithReveal {
                             store_in,
                             guilty_party: source,
@@ -192,13 +185,9 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(ThirdPartyAttributableError::Runtime(error)) => {
-                        TaskResult(TaskResultEnum::RuntimeError { error })
-                    }
-                    Err(ThirdPartyAttributableError::Spurious(error)) => {
-                        TaskResult(TaskResultEnum::SpuriousError { error })
-                    }
-                    Err(ThirdPartyAttributableError::Attributable(error)) => {
+                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
+                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
+                    Err(MaybeAttributableError::Attributable(error)) => {
                         TaskResult(TaskResultEnum::ThirdPartyError { store_in, error })
                     }
                 }
@@ -217,11 +206,9 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(SenderAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
-                    Err(SenderAttributableError::Spurious(error)) => {
-                        TaskResult(TaskResultEnum::SpuriousError { error })
-                    }
-                    Err(SenderAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
+                    Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
+                    Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
+                    Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
                         store_in,
                         guilty_party: source,
                         error,

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -74,7 +74,7 @@ enum ComputeTaskEnum<SP: SessionParameters> {
 pub struct ComputeTask<SP: SessionParameters>(ComputeTaskEnum<SP>);
 
 impl<SP: SessionParameters> ComputeTask<SP> {
-    pub fn compute(self) -> TaskResult<SP> {
+    pub fn execute(self) -> TaskResult<SP> {
         match self.0 {
             ComputeTaskEnum::ScalarUnattributable {
                 store_in,
@@ -246,7 +246,7 @@ enum ComputeWithRngTaskEnum<SP: SessionParameters> {
 pub struct ComputeWithRngTask<SP: SessionParameters>(ComputeWithRngTaskEnum<SP>);
 
 impl<SP: SessionParameters> ComputeWithRngTask<SP> {
-    pub fn compute(self, rng: &mut impl CryptoRngCore) -> TaskResult<SP> {
+    pub fn execute(self, rng: &mut impl CryptoRngCore) -> TaskResult<SP> {
         match self.0 {
             ComputeWithRngTaskEnum::ScalarUnattributable {
                 store_in,
@@ -305,7 +305,7 @@ pub struct SendTask<SP: SessionParameters> {
 }
 
 impl<SP: SessionParameters> SendTask<SP> {
-    pub fn compute(self) -> (Option<Message<SP>>, TaskResult<SP>) {
+    pub fn execute(self) -> (Option<Message<SP>>, TaskResult<SP>) {
         let signed_value = match self.signed_value.downcast::<SignedValue<SP>>() {
             Ok(value) => value,
             Err(error) => return (None, TaskResult(TaskResultEnum::RuntimeError { error })),

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -7,13 +7,12 @@ use crate::{
     entities::{
         Args, ComputedMappingTag, ComputedScalarTag, DeserializeArgs, DeserializeFunction, LocalSignedTag, MappingTag,
         Message, MessageId, ReceivedTag, RemoteSignedTag, RuntimeError, ScalarTag, SenderAttributableError,
-        SenderAttributableErrorEnum, SenderAttributableErrorWithReveal, SenderAttributableErrorWithRevealEnum,
-        SenderAttributableMappingFunction, SenderAttributableWithRevealMappingFunction, SenderError,
-        SenderErrorWithReveal, SentTag, SerializeAndSignFunction, SerializeArgs, SignedValue, SpuriousError,
-        ThirdPartyAttributableError, ThirdPartyAttributableErrorEnum, ThirdPartyAttributableMappingFunction,
-        ThirdPartyError, UnattributableError, UnattributableMappingFunction, UnattributableMappingFunctionWithRng,
-        UnattributableOptionalScalarFunction, UnattributableScalarFunction, UnattributableScalarFunctionWithRng, Value,
-        VerificationError,
+        SenderAttributableErrorWithReveal, SenderAttributableMappingFunction,
+        SenderAttributableWithRevealMappingFunction, SenderError, SenderErrorWithReveal, SentTag,
+        SerializeAndSignFunction, SerializeArgs, SignedValue, SpuriousError, ThirdPartyAttributableError,
+        ThirdPartyAttributableMappingFunction, ThirdPartyError, UnattributableError, UnattributableMappingFunction,
+        UnattributableMappingFunctionWithRng, UnattributableOptionalScalarFunction, UnattributableScalarFunction,
+        UnattributableScalarFunctionWithRng, Value, VerificationError,
     },
     flat_representation::OnError,
     traits::SessionParameters,
@@ -138,20 +137,16 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(SenderAttributableError(SenderAttributableErrorEnum::Runtime(error))) => {
-                        TaskResult(TaskResultEnum::RuntimeError { error })
-                    }
-                    Err(SenderAttributableError(SenderAttributableErrorEnum::Spurious(error))) => {
+                    Err(SenderAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
+                    Err(SenderAttributableError::Spurious(error)) => {
                         TaskResult(TaskResultEnum::SpuriousError { error })
                     }
-                    Err(SenderAttributableError(SenderAttributableErrorEnum::Attributable(error))) => {
-                        TaskResult(TaskResultEnum::SenderError {
-                            store_in,
-                            guilty_party: source,
-                            error,
-                            on_error,
-                        })
-                    }
+                    Err(SenderAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
+                        store_in,
+                        guilty_party: source,
+                        error,
+                        on_error,
+                    }),
                 }
             }
             ComputeTaskEnum::MappingElementSenderAttributableWithReveal {
@@ -168,20 +163,20 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(SenderAttributableErrorWithReveal(SenderAttributableErrorWithRevealEnum::Runtime(error))) => {
+                    Err(SenderAttributableErrorWithReveal::Runtime(error)) => {
                         TaskResult(TaskResultEnum::RuntimeError { error })
                     }
-                    Err(SenderAttributableErrorWithReveal(SenderAttributableErrorWithRevealEnum::Spurious(error))) => {
+                    Err(SenderAttributableErrorWithReveal::Spurious(error)) => {
                         TaskResult(TaskResultEnum::SpuriousError { error })
                     }
-                    Err(SenderAttributableErrorWithReveal(SenderAttributableErrorWithRevealEnum::Attributable(
-                        error,
-                    ))) => TaskResult(TaskResultEnum::SenderErrorWithReveal {
-                        store_in,
-                        guilty_party: source,
-                        error,
-                        on_error,
-                    }),
+                    Err(SenderAttributableErrorWithReveal::Attributable(error)) => {
+                        TaskResult(TaskResultEnum::SenderErrorWithReveal {
+                            store_in,
+                            guilty_party: source,
+                            error,
+                            on_error,
+                        })
+                    }
                 }
             }
             ComputeTaskEnum::MappingElementThirdPartyAttributable {
@@ -197,20 +192,15 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(ThirdPartyAttributableError(ThirdPartyAttributableErrorEnum::Runtime(error))) => {
+                    Err(ThirdPartyAttributableError::Runtime(error)) => {
                         TaskResult(TaskResultEnum::RuntimeError { error })
                     }
-                    Err(ThirdPartyAttributableError(ThirdPartyAttributableErrorEnum::Spurious(error))) => {
+                    Err(ThirdPartyAttributableError::Spurious(error)) => {
                         TaskResult(TaskResultEnum::SpuriousError { error })
                     }
-                    Err(ThirdPartyAttributableError(ThirdPartyAttributableErrorEnum::Attributable {
-                        guilty_party,
-                        error,
-                    })) => TaskResult(TaskResultEnum::ThirdPartyError {
-                        store_in,
-                        guilty_party,
-                        error,
-                    }),
+                    Err(ThirdPartyAttributableError::Attributable(error)) => {
+                        TaskResult(TaskResultEnum::ThirdPartyError { store_in, error })
+                    }
                 }
             }
             ComputeTaskEnum::DeserializeElement {
@@ -227,20 +217,16 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(SenderAttributableError(SenderAttributableErrorEnum::Runtime(error))) => {
-                        TaskResult(TaskResultEnum::RuntimeError { error })
-                    }
-                    Err(SenderAttributableError(SenderAttributableErrorEnum::Spurious(error))) => {
+                    Err(SenderAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
+                    Err(SenderAttributableError::Spurious(error)) => {
                         TaskResult(TaskResultEnum::SpuriousError { error })
                     }
-                    Err(SenderAttributableError(SenderAttributableErrorEnum::Attributable(error))) => {
-                        TaskResult(TaskResultEnum::SenderError {
-                            store_in,
-                            guilty_party: source,
-                            error,
-                            on_error,
-                        })
-                    }
+                    Err(SenderAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
+                        store_in,
+                        guilty_party: source,
+                        error,
+                        on_error,
+                    }),
                 }
             }
             ComputeTaskEnum::PreprocessMessage { task } => task.execute(),
@@ -561,7 +547,6 @@ pub(crate) enum TaskResultEnum<SP: SessionParameters> {
     },
     ThirdPartyError {
         store_in: MappingTag,
-        guilty_party: SP::Verifier,
         error: ThirdPartyError<SP>,
     },
     Preprocessed {

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -9,7 +9,7 @@ use crate::{
         Message, MessageId, ReceivedTag, RemoteSignedTag, RuntimeError, ScalarTag, SenderAttributableError,
         SenderAttributableErrorEnum, SenderAttributableErrorWithReveal, SenderAttributableErrorWithRevealEnum,
         SenderAttributableMappingFunction, SenderAttributableWithRevealMappingFunction, SenderError,
-        SenderErrorWithReveal, SentTag, SerializeAndSignFunction, SerializeArgs, SignedValue,
+        SenderErrorWithReveal, SentTag, SerializeAndSignFunction, SerializeArgs, SignedValue, SpuriousError,
         ThirdPartyAttributableError, ThirdPartyAttributableErrorEnum, ThirdPartyAttributableMappingFunction,
         ThirdPartyError, UnattributableError, UnattributableMappingFunction, UnattributableMappingFunctionWithRng,
         UnattributableOptionalScalarFunction, UnattributableScalarFunction, UnattributableScalarFunctionWithRng, Value,
@@ -72,10 +72,6 @@ enum ComputeTaskEnum<SP: SessionParameters> {
     },
 }
 
-fn unattributable_error_to_result<SP: SessionParameters>(error: impl Into<UnattributableError>) -> TaskResult<SP> {
-    TaskResult(TaskResultEnum::UnattributableError { error: error.into() })
-}
-
 #[derive_where::derive_where(Debug)]
 pub struct ComputeTask<SP: SessionParameters>(ComputeTaskEnum<SP>);
 
@@ -90,7 +86,8 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                 let store_in = ScalarTag::Computed(store_in);
                 match function.call(&args) {
                     Ok(result) => TaskResult(TaskResultEnum::ComputedScalar { store_in, result }),
-                    Err(error) => unattributable_error_to_result(error),
+                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
+                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
                 }
             }
             ComputeTaskEnum::ScalarUnattributableOptional {
@@ -107,7 +104,7 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                             result: value,
                         },
                     )),
-                    Err(error) => unattributable_error_to_result(error),
+                    Err(error) => TaskResult(TaskResultEnum::RuntimeError { error }),
                 }
             }
             ComputeTaskEnum::MappingElementUnattributable {
@@ -123,7 +120,8 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(error) => unattributable_error_to_result(error),
+                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
+                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
                 }
             }
             ComputeTaskEnum::MappingElementSenderAttributable {
@@ -140,8 +138,11 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(SenderAttributableError(SenderAttributableErrorEnum::Unattributable(error))) => {
-                        unattributable_error_to_result(error)
+                    Err(SenderAttributableError(SenderAttributableErrorEnum::Runtime(error))) => {
+                        TaskResult(TaskResultEnum::RuntimeError { error })
+                    }
+                    Err(SenderAttributableError(SenderAttributableErrorEnum::Spurious(error))) => {
+                        TaskResult(TaskResultEnum::SpuriousError { error })
                     }
                     Err(SenderAttributableError(SenderAttributableErrorEnum::Attributable(error))) => {
                         TaskResult(TaskResultEnum::SenderError {
@@ -167,9 +168,12 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(SenderAttributableErrorWithReveal(SenderAttributableErrorWithRevealEnum::Unattributable(
-                        error,
-                    ))) => unattributable_error_to_result(error),
+                    Err(SenderAttributableErrorWithReveal(SenderAttributableErrorWithRevealEnum::Runtime(error))) => {
+                        TaskResult(TaskResultEnum::RuntimeError { error })
+                    }
+                    Err(SenderAttributableErrorWithReveal(SenderAttributableErrorWithRevealEnum::Spurious(error))) => {
+                        TaskResult(TaskResultEnum::SpuriousError { error })
+                    }
                     Err(SenderAttributableErrorWithReveal(SenderAttributableErrorWithRevealEnum::Attributable(
                         error,
                     ))) => TaskResult(TaskResultEnum::SenderErrorWithReveal {
@@ -193,8 +197,11 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(ThirdPartyAttributableError(ThirdPartyAttributableErrorEnum::Unattributable(error))) => {
-                        unattributable_error_to_result(error)
+                    Err(ThirdPartyAttributableError(ThirdPartyAttributableErrorEnum::Runtime(error))) => {
+                        TaskResult(TaskResultEnum::RuntimeError { error })
+                    }
+                    Err(ThirdPartyAttributableError(ThirdPartyAttributableErrorEnum::Spurious(error))) => {
+                        TaskResult(TaskResultEnum::SpuriousError { error })
                     }
                     Err(ThirdPartyAttributableError(ThirdPartyAttributableErrorEnum::Attributable {
                         guilty_party,
@@ -220,8 +227,11 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                         source,
                         result,
                     }),
-                    Err(SenderAttributableError(SenderAttributableErrorEnum::Unattributable(error))) => {
-                        unattributable_error_to_result(error)
+                    Err(SenderAttributableError(SenderAttributableErrorEnum::Runtime(error))) => {
+                        TaskResult(TaskResultEnum::RuntimeError { error })
+                    }
+                    Err(SenderAttributableError(SenderAttributableErrorEnum::Spurious(error))) => {
+                        TaskResult(TaskResultEnum::SpuriousError { error })
                     }
                     Err(SenderAttributableError(SenderAttributableErrorEnum::Attributable(error))) => {
                         TaskResult(TaskResultEnum::SenderError {
@@ -233,10 +243,7 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                     }
                 }
             }
-            ComputeTaskEnum::PreprocessMessage { task } => match task.execute() {
-                Ok(result) => result,
-                Err(error) => unattributable_error_to_result(error),
-            },
+            ComputeTaskEnum::PreprocessMessage { task } => task.execute(),
         }
     }
 }
@@ -276,7 +283,8 @@ impl<SP: SessionParameters> ComputeWithRngTask<SP> {
                 let store_in = ScalarTag::Computed(store_in);
                 match function.call(rng, &args) {
                     Ok(result) => TaskResult(TaskResultEnum::ComputedScalar { store_in, result }),
-                    Err(error) => unattributable_error_to_result(error),
+                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
+                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
                 }
             }
             ComputeWithRngTaskEnum::MappingElementUnattributable {
@@ -292,7 +300,8 @@ impl<SP: SessionParameters> ComputeWithRngTask<SP> {
                         source,
                         result,
                     }),
-                    Err(error) => unattributable_error_to_result(error),
+                    Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError { error }),
+                    Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError { error }),
                 }
             }
             ComputeWithRngTaskEnum::SerializeAndSignElement {
@@ -308,7 +317,7 @@ impl<SP: SessionParameters> ComputeWithRngTask<SP> {
                         source,
                         result,
                     }),
-                    Err(error) => unattributable_error_to_result(error),
+                    Err(error) => TaskResult(TaskResultEnum::RuntimeError { error }),
                 }
             }
         }
@@ -326,7 +335,7 @@ impl<SP: SessionParameters> SendTask<SP> {
     pub fn compute(self) -> (Option<Message<SP>>, TaskResult<SP>) {
         let signed_value = match self.signed_value.downcast::<SignedValue<SP>>() {
             Ok(value) => value,
-            Err(error) => return (None, unattributable_error_to_result(error)),
+            Err(error) => return (None, TaskResult(TaskResultEnum::RuntimeError { error })),
         };
         let signed_values = vec![signed_value];
         let message = Message::new(self.destination.clone(), signed_values);
@@ -532,8 +541,11 @@ pub(crate) enum TaskResultEnum<SP: SessionParameters> {
         source: SP::Verifier,
         result: Value,
     },
-    UnattributableError {
-        error: UnattributableError,
+    RuntimeError {
+        error: RuntimeError,
+    },
+    SpuriousError {
+        error: SpuriousError,
     },
     SenderError {
         store_in: MappingTag,
@@ -583,7 +595,7 @@ impl<SP: SessionParameters> PreprocessingTask<SP> {
         }
     }
 
-    pub fn execute(self) -> Result<TaskResult<SP>, RuntimeError> {
+    pub fn execute(self) -> TaskResult<SP> {
         // Before storing the value in the database, we check for the failures that are unattributable at this level.
         // In case of a failure all we can do is report the message ID and let the user deal with it
         // if their transport protocol allows it.
@@ -596,10 +608,10 @@ impl<SP: SessionParameters> PreprocessingTask<SP> {
         // If it is not, even if we detect something provably wrong with it,
         // the proof will be useless.
         if !self.session_data.participants.contains(self.signed_value.source()) {
-            return Ok(TaskResult(TaskResultEnum::MessageError {
+            return TaskResult(TaskResultEnum::MessageError {
                 message_id: self.message_id,
                 description: format!("A sender {source:?} is not one of the participants"),
-            }));
+            });
         }
 
         // Check that the message is addressed to a correct destination (one that this node manages).
@@ -609,43 +621,43 @@ impl<SP: SessionParameters> PreprocessingTask<SP> {
             .local_participants
             .contains(self.signed_value.metadata().destination())
         {
-            return Ok(TaskResult(TaskResultEnum::MessageError {
+            return TaskResult(TaskResultEnum::MessageError {
                 message_id: self.message_id,
                 description: format!(
                     "A destination {:?} is not one of the local participants",
                     self.signed_value.metadata().destination()
                 ),
-            }));
+            });
         }
 
         // Check that the value belongs to the this session.
         // If it does not, it may be a replay attack.
         if self.signed_value.metadata().session_id() != &self.session_data.id {
-            return Ok(TaskResult(TaskResultEnum::MessageError {
+            return TaskResult(TaskResultEnum::MessageError {
                 message_id: self.message_id,
                 description: "Invalid session ID".into(),
-            }));
+            });
         }
 
         // Verify the value signature.
         let verified_value = match self.signed_value.verify(&self.message_id) {
             Ok(value) => value,
-            Err(VerificationError::Runtime(error)) => return Err(error),
+            Err(VerificationError::Runtime(error)) => return TaskResult(TaskResultEnum::RuntimeError { error }),
             Err(VerificationError::SignatureMismatch) => {
-                return Ok(TaskResult(TaskResultEnum::MessageError {
+                return TaskResult(TaskResultEnum::MessageError {
                     message_id: self.message_id.clone(),
                     description: format!("Verification error for a message from {source:?}"),
-                }));
+                });
             }
         };
 
         let store_in = RemoteSignedTag::new_with_full_name(verified_value.metadata().full_name());
         let value = Value::new(verified_value);
 
-        Ok(TaskResult(TaskResultEnum::Preprocessed {
+        TaskResult(TaskResultEnum::Preprocessed {
             store_in: MappingTag::RemoteSigned(store_in),
             source,
             value,
-        }))
+        })
     }
 }

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -21,7 +21,7 @@ use crate::{
 use crate::protocol_user_api::Session;
 
 #[derive_where::derive_where(Debug)]
-enum ComputeTaskEnum<SP: SessionParameters> {
+enum DeterministicTaskEnum<SP: SessionParameters> {
     ScalarUnattributable {
         store_in: ComputedScalarTag,
         function: UnattributableScalarFunction<SP>,
@@ -69,12 +69,12 @@ enum ComputeTaskEnum<SP: SessionParameters> {
 }
 
 #[derive_where::derive_where(Debug)]
-pub struct ComputeTask<SP: SessionParameters>(ComputeTaskEnum<SP>);
+pub struct DeterministicTask<SP: SessionParameters>(DeterministicTaskEnum<SP>);
 
-impl<SP: SessionParameters> ComputeTask<SP> {
+impl<SP: SessionParameters> DeterministicTask<SP> {
     pub fn execute(self) -> TaskResult<SP> {
         match self.0 {
-            ComputeTaskEnum::ScalarUnattributable {
+            DeterministicTaskEnum::ScalarUnattributable {
                 store_in,
                 function,
                 args,
@@ -86,7 +86,7 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                     Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
                 }
             }
-            ComputeTaskEnum::ScalarUnattributableOptional {
+            DeterministicTaskEnum::ScalarUnattributableOptional {
                 store_in,
                 function,
                 args,
@@ -103,7 +103,7 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                     Err(error) => TaskResult(TaskResultEnum::RuntimeError(error)),
                 }
             }
-            ComputeTaskEnum::MappingElementUnattributable {
+            DeterministicTaskEnum::MappingElementUnattributable {
                 store_in,
                 function,
                 source,
@@ -120,7 +120,7 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                     Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
                 }
             }
-            ComputeTaskEnum::MappingElementSenderAttributable {
+            DeterministicTaskEnum::MappingElementSenderAttributable {
                 store_in,
                 function,
                 source,
@@ -144,7 +144,7 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                     }),
                 }
             }
-            ComputeTaskEnum::MappingElementSenderAttributableWithReveal {
+            DeterministicTaskEnum::MappingElementSenderAttributableWithReveal {
                 store_in,
                 function,
                 source,
@@ -170,7 +170,7 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                     }
                 }
             }
-            ComputeTaskEnum::MappingElementThirdPartyAttributable {
+            DeterministicTaskEnum::MappingElementThirdPartyAttributable {
                 store_in,
                 function,
                 source,
@@ -190,7 +190,7 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                     }
                 }
             }
-            ComputeTaskEnum::DeserializeElement {
+            DeterministicTaskEnum::DeserializeElement {
                 store_in,
                 function,
                 source,
@@ -214,13 +214,13 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                     }),
                 }
             }
-            ComputeTaskEnum::PreprocessMessage(task) => task.execute(),
+            DeterministicTaskEnum::PreprocessMessage(task) => task.execute(),
         }
     }
 }
 
 #[derive_where::derive_where(Debug)]
-enum ComputeWithRngTaskEnum<SP: SessionParameters> {
+enum RandomizedTaskEnum<SP: SessionParameters> {
     ScalarUnattributable {
         store_in: ComputedScalarTag,
         function: UnattributableScalarFunctionWithRng<SP>,
@@ -241,12 +241,12 @@ enum ComputeWithRngTaskEnum<SP: SessionParameters> {
 }
 
 #[derive_where::derive_where(Debug)]
-pub struct ComputeWithRngTask<SP: SessionParameters>(ComputeWithRngTaskEnum<SP>);
+pub struct RandomizedTask<SP: SessionParameters>(RandomizedTaskEnum<SP>);
 
-impl<SP: SessionParameters> ComputeWithRngTask<SP> {
+impl<SP: SessionParameters> RandomizedTask<SP> {
     pub fn execute(self, rng: &mut impl CryptoRngCore) -> TaskResult<SP> {
         match self.0 {
-            ComputeWithRngTaskEnum::ScalarUnattributable {
+            RandomizedTaskEnum::ScalarUnattributable {
                 store_in,
                 function,
                 args,
@@ -258,7 +258,7 @@ impl<SP: SessionParameters> ComputeWithRngTask<SP> {
                     Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
                 }
             }
-            ComputeWithRngTaskEnum::MappingElementUnattributable {
+            RandomizedTaskEnum::MappingElementUnattributable {
                 store_in,
                 function,
                 source,
@@ -275,7 +275,7 @@ impl<SP: SessionParameters> ComputeWithRngTask<SP> {
                     Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
                 }
             }
-            ComputeWithRngTaskEnum::SerializeAndSignElement {
+            RandomizedTaskEnum::SerializeAndSignElement {
                 store_in,
                 function,
                 source,
@@ -324,14 +324,14 @@ pub enum Task<SP: SessionParameters> {
     /// Send an outgoing message.
     Send(SendTask<SP>),
     /// Perform a dererministic computation.
-    Compute(ComputeTask<SP>),
+    Deterministic(DeterministicTask<SP>),
     /// Perform a computation that needs access to an RNG.
-    ComputeWithRng(ComputeWithRngTask<SP>),
+    Randomized(RandomizedTask<SP>),
 }
 
 impl<SP: SessionParameters> Task<SP> {
     pub(crate) fn preprocess_message(task: PreprocessingTask<SP>) -> Self {
-        Self::Compute(ComputeTask(ComputeTaskEnum::PreprocessMessage(task)))
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::PreprocessMessage(task)))
     }
 
     pub(crate) fn direct_message(store_in: SentTag, destination: SP::Verifier, signed_value: Value) -> Self {
@@ -347,7 +347,7 @@ impl<SP: SessionParameters> Task<SP> {
         function: UnattributableScalarFunction<SP>,
         args: Args<SP>,
     ) -> Self {
-        Self::Compute(ComputeTask(ComputeTaskEnum::ScalarUnattributable {
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::ScalarUnattributable {
             store_in,
             function,
             args,
@@ -359,7 +359,7 @@ impl<SP: SessionParameters> Task<SP> {
         function: UnattributableOptionalScalarFunction<SP>,
         args: Args<SP>,
     ) -> Self {
-        Self::Compute(ComputeTask(ComputeTaskEnum::ScalarUnattributableOptional {
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::ScalarUnattributableOptional {
             store_in,
             function,
             args,
@@ -371,7 +371,7 @@ impl<SP: SessionParameters> Task<SP> {
         function: UnattributableScalarFunctionWithRng<SP>,
         args: Args<SP>,
     ) -> Self {
-        Self::ComputeWithRng(ComputeWithRngTask(ComputeWithRngTaskEnum::ScalarUnattributable {
+        Self::Randomized(RandomizedTask(RandomizedTaskEnum::ScalarUnattributable {
             store_in,
             function,
             args,
@@ -384,7 +384,7 @@ impl<SP: SessionParameters> Task<SP> {
         function: UnattributableMappingFunction<SP>,
         args: Args<SP>,
     ) -> Self {
-        Self::Compute(ComputeTask(ComputeTaskEnum::MappingElementUnattributable {
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::MappingElementUnattributable {
             store_in,
             source,
             function,
@@ -398,14 +398,12 @@ impl<SP: SessionParameters> Task<SP> {
         function: UnattributableMappingFunctionWithRng<SP>,
         args: Args<SP>,
     ) -> Self {
-        Self::ComputeWithRng(ComputeWithRngTask(
-            ComputeWithRngTaskEnum::MappingElementUnattributable {
-                store_in,
-                source,
-                function,
-                args,
-            },
-        ))
+        Self::Randomized(RandomizedTask(RandomizedTaskEnum::MappingElementUnattributable {
+            store_in,
+            source,
+            function,
+            args,
+        }))
     }
 
     pub(crate) fn compute_serialize_and_sign_elem(
@@ -414,7 +412,7 @@ impl<SP: SessionParameters> Task<SP> {
         function: SerializeAndSignFunction<SP>,
         args: SerializeArgs<SP>,
     ) -> Self {
-        Self::ComputeWithRng(ComputeWithRngTask(ComputeWithRngTaskEnum::SerializeAndSignElement {
+        Self::Randomized(RandomizedTask(RandomizedTaskEnum::SerializeAndSignElement {
             store_in,
             source,
             function,
@@ -429,7 +427,7 @@ impl<SP: SessionParameters> Task<SP> {
         args: DeserializeArgs<SP>,
         on_error: OnError,
     ) -> Self {
-        Self::Compute(ComputeTask(ComputeTaskEnum::DeserializeElement {
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::DeserializeElement {
             store_in,
             source,
             function,
@@ -445,13 +443,15 @@ impl<SP: SessionParameters> Task<SP> {
         args: Args<SP>,
         on_error: OnError,
     ) -> Self {
-        Self::Compute(ComputeTask(ComputeTaskEnum::MappingElementSenderAttributable {
-            store_in,
-            source,
-            function,
-            args,
-            on_error,
-        }))
+        Self::Deterministic(DeterministicTask(
+            DeterministicTaskEnum::MappingElementSenderAttributable {
+                store_in,
+                source,
+                function,
+                args,
+                on_error,
+            },
+        ))
     }
 
     pub(crate) fn compute_mapping_elem_sender_attributable_with_reveal(
@@ -461,8 +461,8 @@ impl<SP: SessionParameters> Task<SP> {
         args: Args<SP>,
         on_error: OnError,
     ) -> Self {
-        Self::Compute(ComputeTask(
-            ComputeTaskEnum::MappingElementSenderAttributableWithReveal {
+        Self::Deterministic(DeterministicTask(
+            DeterministicTaskEnum::MappingElementSenderAttributableWithReveal {
                 store_in,
                 source,
                 function,
@@ -478,12 +478,14 @@ impl<SP: SessionParameters> Task<SP> {
         function: ThirdPartyAttributableMappingFunction<SP>,
         args: Args<SP>,
     ) -> Self {
-        Self::Compute(ComputeTask(ComputeTaskEnum::MappingElementThirdPartyAttributable {
-            store_in,
-            source,
-            function,
-            args,
-        }))
+        Self::Deterministic(DeterministicTask(
+            DeterministicTaskEnum::MappingElementThirdPartyAttributable {
+                store_in,
+                source,
+                function,
+                args,
+            },
+        ))
     }
 }
 

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -5,8 +5,8 @@ use signature::rand_core::CryptoRngCore;
 use super::session::SessionData;
 use crate::{
     entities::{
-        Args, ComputedMappingTag, ComputedScalarTag, DeserializeArgs, DeserializeFunction, LocalSignedTag, MappingTag,
-        MaybeAttributableError, Message, MessageId, ReceivedTag, RemoteSignedTag, RuntimeError, ScalarTag,
+        AnyTag, Args, ComputedMappingTag, ComputedScalarTag, DeserializeArgs, DeserializeFunction, LocalSignedTag,
+        MappingTag, MaybeAttributableError, Message, MessageId, ReceivedTag, RemoteSignedTag, RuntimeError, ScalarTag,
         SenderAttributableMappingFunction, SenderAttributableWithRevealMappingFunction, SenderError,
         SenderErrorWithReveal, SentTag, SerializeAndSignFunction, SerializeArgs, SignedValue, SpuriousError,
         ThirdPartyAttributableMappingFunction, ThirdPartyError, UnattributableError, UnattributableMappingFunction,
@@ -41,7 +41,10 @@ impl<SP: SessionParameters> ScalarUnattributableTask<SP> {
         match self.function.call(&self.args) {
             Ok(result) => TaskResult(TaskResultEnum::ComputedScalar { store_in, result }),
             Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-            Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+            Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError {
+                store_in: AnyTag::Scalar(store_in),
+                error,
+            }),
         }
     }
 }
@@ -127,7 +130,10 @@ impl<SP: SessionParameters> ElementUnattributableTask<SP> {
                 result,
             }),
             Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-            Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+            Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError {
+                store_in: AnyTag::Mapping(store_in),
+                error,
+            }),
         }
     }
 }
@@ -173,7 +179,10 @@ impl<SP: SessionParameters> ElementSenderAttributableTask<SP> {
                 result,
             }),
             Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError {
+                store_in: AnyTag::Mapping(store_in),
+                error,
+            }),
             Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
                 store_in,
                 guilty_party: self.index,
@@ -227,7 +236,10 @@ impl<SP: SessionParameters> ElementSenderAttributableWithRevealTask<SP> {
                 result,
             }),
             Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError {
+                store_in: AnyTag::Mapping(store_in),
+                error,
+            }),
             Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderErrorWithReveal {
                 store_in,
                 guilty_party: self.index,
@@ -278,7 +290,10 @@ impl<SP: SessionParameters> ElementThirdPartyAttributableTask<SP> {
                 result,
             }),
             Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError {
+                store_in: AnyTag::Mapping(store_in),
+                error,
+            }),
             Err(MaybeAttributableError::Attributable(error)) => {
                 TaskResult(TaskResultEnum::ThirdPartyError { store_in, error })
             }
@@ -329,7 +344,10 @@ impl<SP: SessionParameters> DeserializeElementTask<SP> {
                 result,
             }),
             Err(MaybeAttributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+            Err(MaybeAttributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError {
+                store_in: AnyTag::Mapping(store_in),
+                error,
+            }),
             Err(MaybeAttributableError::Attributable(error)) => TaskResult(TaskResultEnum::SenderError {
                 store_in,
                 guilty_party: self.index,
@@ -367,7 +385,10 @@ impl<SP: SessionParameters> RngScalarUnattributableTask<SP> {
         match self.function.call(rng, &self.args) {
             Ok(result) => TaskResult(TaskResultEnum::ComputedScalar { store_in, result }),
             Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-            Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+            Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError {
+                store_in: AnyTag::Scalar(store_in),
+                error,
+            }),
         }
     }
 }
@@ -410,7 +431,10 @@ impl<SP: SessionParameters> RngElementUnattributableTask<SP> {
                 result,
             }),
             Err(UnattributableError::Runtime(error)) => TaskResult(TaskResultEnum::RuntimeError(error)),
-            Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError(error)),
+            Err(UnattributableError::Spurious(error)) => TaskResult(TaskResultEnum::SpuriousError {
+                store_in: AnyTag::Mapping(store_in),
+                error,
+            }),
         }
     }
 }
@@ -681,7 +705,10 @@ pub(crate) enum TaskResultEnum<SP: SessionParameters> {
         value: Value,
     },
     RuntimeError(RuntimeError),
-    SpuriousError(SpuriousError),
+    SpuriousError {
+        store_in: AnyTag,
+        error: SpuriousError,
+    },
     SenderError {
         store_in: MappingTag,
         guilty_party: SP::Verifier,

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -96,7 +96,7 @@ impl<SP: SessionParameters> ComputeTask<SP> {
                 let store_in = ScalarTag::Computed(store_in);
                 match function.call(&args) {
                     Ok(result) => TaskResult(result.map_or_else(
-                        || TaskResultEnum::Success,
+                        || TaskResultEnum::NoActionNeeded,
                         |value| TaskResultEnum::ComputedScalar {
                             store_in,
                             result: value,
@@ -500,7 +500,7 @@ impl<SP: SessionParameters> TaskResult<SP> {
 
 #[derive_where::derive_where(Debug)]
 pub(crate) enum TaskResultEnum<SP: SessionParameters> {
-    Success,
+    NoActionNeeded,
     Sent {
         store_in: MappingTag,
         destination: SP::Verifier,
@@ -513,6 +513,11 @@ pub(crate) enum TaskResultEnum<SP: SessionParameters> {
         store_in: MappingTag,
         source: SP::Verifier,
         result: Value,
+    },
+    Preprocessed {
+        store_in: MappingTag,
+        source: SP::Verifier,
+        value: Value,
     },
     RuntimeError {
         error: RuntimeError,
@@ -535,11 +540,6 @@ pub(crate) enum TaskResultEnum<SP: SessionParameters> {
     ThirdPartyError {
         store_in: MappingTag,
         error: ThirdPartyError<SP>,
-    },
-    Preprocessed {
-        store_in: MappingTag,
-        source: SP::Verifier,
-        value: Value,
     },
     MessageError {
         message_id: MessageId<SP>,

--- a/ayatori/src/execution/tokio.rs
+++ b/ayatori/src/execution/tokio.rs
@@ -87,11 +87,11 @@ where
     loop {
         while let Some(task) = session.make_task().or_with_context(|| "Failed to make a task".into())? {
             let task_result = match task {
-                Task::Compute(task) => {
+                Task::Deterministic(task) => {
                     let result = task.execute();
                     session.add_result(result)
                 }
-                Task::ComputeWithRng(task) => {
+                Task::Randomized(task) => {
                     let result = task.execute(rng);
                     session.add_result(result)
                 }
@@ -218,10 +218,10 @@ where
     loop {
         while let Some(task) = session.make_task().or_with_context(|| "Failed to make a task".into())? {
             match task {
-                Task::Compute(task) => {
+                Task::Deterministic(task) => {
                     tasks.spawn_blocking(move || Ok(task.execute()));
                 }
-                Task::ComputeWithRng(task) => {
+                Task::Randomized(task) => {
                     let mut task_rng = ChaCha20Rng::from_rng(&mut *rng)
                         .map_err(|err| RuntimeError::new(format!("Failed to create an RNG: {err}")))?;
                     tasks.spawn_blocking(move || Ok(task.execute(&mut task_rng)));

--- a/ayatori/src/execution/tokio.rs
+++ b/ayatori/src/execution/tokio.rs
@@ -13,7 +13,7 @@ use tokio::{sync::mpsc, task::JoinSet};
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    session::{MessageAttributableError, Session, SessionError, SessionReport, SessionState, TaskError},
+    session::{MessageAttributableError, Session, SessionReport, SessionState},
     task::{Task, TaskResult},
 };
 use crate::{
@@ -57,7 +57,7 @@ pub trait SessionRunner<'a, SP: SessionParameters, P: ExecutableProtocol<SP>, R:
     'static + Send + Sync
 {
     /// The returned future.
-    type Fut: Future<Output = Result<SessionReport<SP, P>, SessionError>> + 'a + Send;
+    type Fut: Future<Output = Result<SessionReport<SP, P>, RuntimeError>> + 'a + Send;
 
     /// Calls the function returning the future.
     fn call(
@@ -78,7 +78,7 @@ pub async fn run_session<SP, P>(
     rx: &mut mpsc::Receiver<MessageIn<SP>>,
     cancellation: CancellationToken,
     mut session: Session<SP, P>,
-) -> Result<SessionReport<SP, P>, SessionError>
+) -> Result<SessionReport<SP, P>, RuntimeError>
 where
     SP: SessionParameters,
     SP::Signer: Sync,
@@ -86,7 +86,7 @@ where
 {
     loop {
         while let Some(task) = session.make_task().or_with_context(|| "Failed to make a task".into())? {
-            let task_result = match task {
+            let new_state = match task {
                 Task::Deterministic(task) => {
                     let result = task.execute();
                     session.add_result(result)
@@ -106,23 +106,22 @@ where
                 }
             };
 
-            match task_result {
-                Ok(()) => {}
-                Err(TaskError::Runtime(error)) => return Err(error.into()),
-                Err(TaskError::Spurious(error)) => return Err(error.into()),
-                Err(TaskError::MessageAttributable(error)) => {
+            session = match new_state? {
+                SessionState::InProgress(session) => session,
+                SessionState::InProgressWithMessageError { error, session } => {
                     tx.send(MessageOut::Error(error)).await.map_err(|err| {
                         RuntimeError::new(format!("Failed to send a message to the output channel: {err}"))
                     })?;
+                    session
+                }
+                SessionState::ReachedOutput(success) => {
+                    return success.finalize();
+                }
+                SessionState::Unfinishable(report) => {
+                    return Ok(report);
                 }
             }
         }
-
-        session = match session.try_finalize() {
-            SessionState::InProgress(session) => session,
-            SessionState::ReachedOutput(success) => return Ok(success.finalize()?),
-            SessionState::Stalled(stalled) => return Ok(stalled.finalize()),
-        };
 
         let message_in = tokio::select! {
             message_in = rx.recv() => message_in.ok_or_else(|| {
@@ -209,7 +208,7 @@ async fn par_run_session_inner<SP, P>(
     rx: &mut mpsc::Receiver<MessageIn<SP>>,
     cancellation: CancellationToken,
     mut session: Session<SP, P>,
-) -> Result<SessionReport<SP, P>, SessionError>
+) -> Result<SessionReport<SP, P>, RuntimeError>
 where
     SP: SessionParameters,
     SP::Signer: Send + Sync,
@@ -254,25 +253,24 @@ where
             task_result = tasks.join_next(), if !tasks.is_empty() => {
                 if let Some(task_result) = task_result {
                     let task_result = task_result?;
-                    match session.add_result(task_result) {
-                        Ok(()) => {}
-                        Err(TaskError::Runtime(error)) => return Err(error.into()),
-                        Err(TaskError::Spurious(error)) => return Err(error.into()),
-                        Err(TaskError::MessageAttributable(error)) => {
+                    session = match session.add_result(task_result)? {
+                        SessionState::InProgress(session) => session,
+                        SessionState::InProgressWithMessageError { error, session } => {
                             tx.send(MessageOut::Error(error)).await.map_err(|err| {
                                 RuntimeError::new(format!("Failed to send a message to the output channel: {err}"))
                             })?;
+                            session
+                        },
+                        SessionState::ReachedOutput(success) => {
+                            return success.finalize();
+                        }
+                        SessionState::Unfinishable(report) => {
+                            return Ok(report);
                         }
                     }
                 }
             }
             () = cancellation.cancelled() => return Ok(session.terminate()),
-        };
-
-        session = match session.try_finalize() {
-            SessionState::InProgress(session) => session,
-            SessionState::ReachedOutput(success) => return Ok(success.finalize()?),
-            SessionState::Stalled(stalled) => return Ok(stalled.finalize()),
         };
     }
 }
@@ -290,7 +288,7 @@ pub async fn par_run_session<SP, P>(
     rx: &mut mpsc::Receiver<MessageIn<SP>>,
     cancellation: CancellationToken,
     session: Session<SP, P>,
-) -> Result<SessionReport<SP, P>, SessionError>
+) -> Result<SessionReport<SP, P>, RuntimeError>
 where
     SP: SessionParameters,
     SP::Signer: Send + Sync,

--- a/ayatori/src/execution/tokio.rs
+++ b/ayatori/src/execution/tokio.rs
@@ -18,6 +18,7 @@ use super::{
 };
 use crate::{
     entities::{Message, MessageId, RuntimeError, UnattributableError},
+    error::TraceableResult,
     traits::{ExecutableProtocol, SessionParameters},
 };
 
@@ -84,7 +85,7 @@ where
     P: ExecutableProtocol<SP>,
 {
     loop {
-        while let Some(task) = session.make_task()? {
+        while let Some(task) = session.make_task().or_with_context(|| "Failed to make a task".into())? {
             let task_result = match task {
                 Task::Compute(task) => {
                     let result = task.compute();
@@ -189,8 +190,8 @@ impl<SP: SessionParameters> TaskScope<SP> {
             Ok(())
         } else {
             Err(RuntimeError::new(format!(
-                "Errors during task shutdown: {}",
-                errors.iter().map(ToString::to_string).join(", ")
+                "Errors during task shutdown:\n{}",
+                errors.iter().map(ToString::to_string).join("\n")
             )))
         }
     }
@@ -214,14 +215,14 @@ where
     P: ExecutableProtocol<SP>,
 {
     loop {
-        while let Some(task) = session.make_task()? {
+        while let Some(task) = session.make_task().or_with_context(|| "Failed to make a task".into())? {
             match task {
                 Task::Compute(task) => {
                     tasks.spawn_blocking(move || Ok(task.compute()));
                 }
                 Task::ComputeWithRng(task) => {
                     let mut task_rng = ChaCha20Rng::from_rng(&mut *rng)
-                        .map_err(|err| UnattributableError::runtime(format!("Failed to create an RNG: {err}")))?;
+                        .map_err(|err| RuntimeError::new(format!("Failed to create an RNG: {err}")))?;
                     tasks.spawn_blocking(move || Ok(task.compute(&mut task_rng)));
                 }
                 Task::Send(task) => {

--- a/ayatori/src/execution/tokio.rs
+++ b/ayatori/src/execution/tokio.rs
@@ -13,11 +13,11 @@ use tokio::{sync::mpsc, task::JoinSet};
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    session::{MessageAttributableError, Session, SessionReport, SessionState, TaskError},
+    session::{MessageAttributableError, Session, SessionError, SessionReport, SessionState, TaskError},
     task::{Task, TaskResult},
 };
 use crate::{
-    entities::{Message, MessageId, RuntimeError, UnattributableError},
+    entities::{Message, MessageId, RuntimeError},
     error::TraceableResult,
     traits::{ExecutableProtocol, SessionParameters},
 };
@@ -57,7 +57,7 @@ pub trait SessionRunner<'a, SP: SessionParameters, P: ExecutableProtocol<SP>, R:
     'static + Send + Sync
 {
     /// The returned future.
-    type Fut: Future<Output = Result<SessionReport<SP, P>, UnattributableError>> + 'a + Send;
+    type Fut: Future<Output = Result<SessionReport<SP, P>, SessionError>> + 'a + Send;
 
     /// Calls the function returning the future.
     fn call(
@@ -78,7 +78,7 @@ pub async fn run_session<SP, P>(
     rx: &mut mpsc::Receiver<MessageIn<SP>>,
     cancellation: CancellationToken,
     mut session: Session<SP, P>,
-) -> Result<SessionReport<SP, P>, UnattributableError>
+) -> Result<SessionReport<SP, P>, SessionError>
 where
     SP: SessionParameters,
     SP::Signer: Sync,
@@ -108,7 +108,8 @@ where
 
             match task_result {
                 Ok(()) => {}
-                Err(TaskError::Unattributable(error)) => return Err(error),
+                Err(TaskError::Runtime(error)) => return Err(error.into()),
+                Err(TaskError::Spurious(error)) => return Err(error.into()),
                 Err(TaskError::MessageAttributable(error)) => {
                     tx.send(MessageOut::Error(error)).await.map_err(|err| {
                         RuntimeError::new(format!("Failed to send a message to the output channel: {err}"))
@@ -208,7 +209,7 @@ async fn par_run_session_inner<SP, P>(
     rx: &mut mpsc::Receiver<MessageIn<SP>>,
     cancellation: CancellationToken,
     mut session: Session<SP, P>,
-) -> Result<SessionReport<SP, P>, UnattributableError>
+) -> Result<SessionReport<SP, P>, SessionError>
 where
     SP: SessionParameters,
     SP::Signer: Send + Sync,
@@ -255,7 +256,8 @@ where
                     let task_result = task_result?;
                     match session.add_result(task_result) {
                         Ok(()) => {}
-                        Err(TaskError::Unattributable(error)) => return Err(error),
+                        Err(TaskError::Runtime(error)) => return Err(error.into()),
+                        Err(TaskError::Spurious(error)) => return Err(error.into()),
                         Err(TaskError::MessageAttributable(error)) => {
                             tx.send(MessageOut::Error(error)).await.map_err(|err| {
                                 RuntimeError::new(format!("Failed to send a message to the output channel: {err}"))
@@ -288,7 +290,7 @@ pub async fn par_run_session<SP, P>(
     rx: &mut mpsc::Receiver<MessageIn<SP>>,
     cancellation: CancellationToken,
     session: Session<SP, P>,
-) -> Result<SessionReport<SP, P>, UnattributableError>
+) -> Result<SessionReport<SP, P>, SessionError>
 where
     SP: SessionParameters,
     SP::Signer: Send + Sync,

--- a/ayatori/src/execution/tokio.rs
+++ b/ayatori/src/execution/tokio.rs
@@ -88,15 +88,15 @@ where
         while let Some(task) = session.make_task().or_with_context(|| "Failed to make a task".into())? {
             let task_result = match task {
                 Task::Compute(task) => {
-                    let result = task.compute();
+                    let result = task.execute();
                     session.add_result(result)
                 }
                 Task::ComputeWithRng(task) => {
-                    let result = task.compute(rng);
+                    let result = task.execute(rng);
                     session.add_result(result)
                 }
                 Task::Send(task) => {
-                    let (message, result) = task.compute();
+                    let (message, result) = task.execute();
                     if let Some(message) = message {
                         tx.send(MessageOut::Message(message)).await.map_err(|err| {
                             RuntimeError::new(format!("Failed to send a message to the output channel: {err}"))
@@ -219,17 +219,17 @@ where
         while let Some(task) = session.make_task().or_with_context(|| "Failed to make a task".into())? {
             match task {
                 Task::Compute(task) => {
-                    tasks.spawn_blocking(move || Ok(task.compute()));
+                    tasks.spawn_blocking(move || Ok(task.execute()));
                 }
                 Task::ComputeWithRng(task) => {
                     let mut task_rng = ChaCha20Rng::from_rng(&mut *rng)
                         .map_err(|err| RuntimeError::new(format!("Failed to create an RNG: {err}")))?;
-                    tasks.spawn_blocking(move || Ok(task.compute(&mut task_rng)));
+                    tasks.spawn_blocking(move || Ok(task.execute(&mut task_rng)));
                 }
                 Task::Send(task) => {
                     let tx = tx.clone();
                     tasks.spawn(async move {
-                        let (message, result) = task.compute();
+                        let (message, result) = task.execute();
                         if let Some(message) = message {
                             tx.send(MessageOut::Message(message)).await.map_err(|err| {
                                 RuntimeError::new(format!("Failed to send a message to the outbound channel: {err}"))

--- a/ayatori/src/flat_representation/conditions.rs
+++ b/ayatori/src/flat_representation/conditions.rs
@@ -292,7 +292,7 @@ impl<Id: PartyId> QuorumConditionWithState<Id> {
 
 impl Display for ScalarConditionWithState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "ready({})", self.current_condition)
+        write!(f, "{}", self.current_condition)
     }
 }
 

--- a/ayatori/src/flat_representation/ruleset.rs
+++ b/ayatori/src/flat_representation/ruleset.rs
@@ -243,7 +243,7 @@ impl<SP: SessionParameters> PropagatedGroups<SP> {
 pub(crate) enum RulesetState {
     InProgress,
     ReachedOutput,
-    ImpossibleToCollect(CollectedTag),
+    ImpossibleToCollect(Vec<CollectedTag>),
 }
 
 #[derive_where::derive_where(Debug)]
@@ -443,12 +443,16 @@ impl<SP: SessionParameters> Ruleset<SP> {
     }
 
     pub fn update_with_banned_party(&mut self, id: &SP::Verifier) {
+        let mut impossible_collects = Vec::new();
         for rule in &mut self.collect_rules {
             rule.quorum_condition.update_with_banned_party(id);
             if !rule.quorum_condition.is_satisfiable() {
-                // TODO: include all impossible to collect nodes, and the list of banned parties.
-                self.state = RulesetState::ImpossibleToCollect(rule.store_in.clone());
+                impossible_collects.push(rule.store_in.clone());
             }
+        }
+
+        if !impossible_collects.is_empty() {
+            self.state = RulesetState::ImpossibleToCollect(impossible_collects);
         }
     }
 

--- a/ayatori/src/flat_representation/ruleset.rs
+++ b/ayatori/src/flat_representation/ruleset.rs
@@ -1,5 +1,6 @@
 use alloc::{
     collections::{BTreeMap, BTreeSet},
+    format,
     string::{String, ToString},
     vec::Vec,
 };
@@ -176,9 +177,11 @@ impl<SP: SessionParameters> PropagatedGroups<SP> {
     }
 
     fn get(&self, tag: MappingTagRef<'_>) -> Result<&BTreeSet<SP::Verifier>, RuntimeError> {
-        self.0
-            .get(&tag.to_owned())
-            .ok_or_else(|| RuntimeError::expect("The required IDs were propagated to this node"))
+        self.0.get(&tag.to_owned()).ok_or_else(|| {
+            RuntimeError::expect(format!(
+                "Expected the node {tag} to be present in the propagated groups"
+            ))
+        })
     }
 
     fn new(root: &AnyNode<SP>) -> Result<Self, RuntimeError> {

--- a/ayatori/src/flat_representation/ruleset.rs
+++ b/ayatori/src/flat_representation/ruleset.rs
@@ -243,7 +243,7 @@ impl<SP: SessionParameters> PropagatedGroups<SP> {
 pub(crate) enum RulesetState {
     InProgress,
     ReachedOutput,
-    StalledAt(CollectedTag),
+    ImpossibleToCollect(CollectedTag),
 }
 
 #[derive_where::derive_where(Debug)]
@@ -446,7 +446,8 @@ impl<SP: SessionParameters> Ruleset<SP> {
         for rule in &mut self.collect_rules {
             rule.quorum_condition.update_with_banned_party(id);
             if !rule.quorum_condition.is_satisfiable() {
-                self.state = RulesetState::StalledAt(rule.store_in.clone());
+                // TODO: include all impossible to collect nodes, and the list of banned parties.
+                self.state = RulesetState::ImpossibleToCollect(rule.store_in.clone());
             }
         }
     }

--- a/ayatori/src/flat_representation/ruleset.rs
+++ b/ayatori/src/flat_representation/ruleset.rs
@@ -177,8 +177,11 @@ impl<SP: SessionParameters> PropagatedGroups<SP> {
     }
 
     fn get(&self, tag: MappingTagRef<'_>) -> Result<&BTreeSet<SP::Verifier>, RuntimeError> {
+        // This is an internal method which we only call in the places where by construction it cannot fail
+        // (in `Self::new()`, because of the order in which we process nodes;
+        // in `Ruleset::new()`, because we call it for the nodes of the tree that was used to create `Self`).
         self.0.get(&tag.to_owned()).ok_or_else(|| {
-            RuntimeError::expect(format!(
+            RuntimeError::new(format!(
                 "Expected the node {tag} to be present in the propagated groups"
             ))
         })

--- a/ayatori/src/flat_representation/ruleset.rs
+++ b/ayatori/src/flat_representation/ruleset.rs
@@ -78,8 +78,8 @@ enum MappingRuleKind<SP: SessionParameters> {
         store_in: ReceivedTag,
         function: DeserializeFunction<SP>,
         data: RemoteSignedTag,
-        message_name: FullName,
         serde_adapter: SerdeAdapter<SP::WireFormat>,
+        expected_senders: BTreeSet<SP::Verifier>,
         on_error: OnError,
     },
 }
@@ -126,8 +126,8 @@ pub(crate) enum Action<SP: SessionParameters> {
         index: SP::Verifier,
         function: DeserializeFunction<SP>,
         data: RemoteSignedTag,
-        message_name: FullName,
         serde_adapter: SerdeAdapter<SP::WireFormat>,
+        expected_senders: BTreeSet<SP::Verifier>,
         on_error: OnError,
     },
     DirectMessage {
@@ -253,7 +253,6 @@ pub(crate) struct Ruleset<SP: SessionParameters> {
     collect_rules: Vec<CollectRule<SP>>,
     mapping_rules: Vec<MappingRule<SP>>,
     send_rules: Vec<SendRule<SP>>,
-    expected_messages: BTreeMap<FullName, BTreeSet<SP::Verifier>>,
     arguments: BTreeMap<String, ScalarArgumentTag>,
     state: RulesetState,
 }
@@ -371,6 +370,12 @@ impl<SP: SessionParameters> Ruleset<SP> {
 
                     let element_condition = ElementCondition::from_deserialize_and_check(node);
 
+                    // We expect the expected senders to be present because they are added by the `Receive` node,
+                    // which is an argument to this node, so it would have been processed previously.
+                    let expected_senders = expected_messages.get(&node.message_name).cloned().ok_or_else(|| {
+                        RuntimeError::new(format!("Expected senders for `{}` to be available", node.message_name))
+                    })?;
+
                     mapping_rules.push(MappingRule {
                         dependencies_condition,
                         scalar_condition: ScalarConditionWithState::new(ScalarCondition::empty()),
@@ -379,8 +384,8 @@ impl<SP: SessionParameters> Ruleset<SP> {
                             store_in: node.store_in.clone(),
                             function: node.function.clone(),
                             data: node.data.as_ref().store_in.clone(),
-                            message_name: node.message_name.clone(),
                             serde_adapter: node.serde_adapter.clone(),
+                            expected_senders,
                             on_error,
                         },
                     });
@@ -436,7 +441,6 @@ impl<SP: SessionParameters> Ruleset<SP> {
             collect_rules,
             mapping_rules,
             send_rules,
-            expected_messages,
             arguments,
             state: RulesetState::InProgress,
         })
@@ -586,16 +590,16 @@ impl<SP: SessionParameters> Ruleset<SP> {
                         store_in,
                         function,
                         data,
-                        message_name,
                         serde_adapter,
+                        expected_senders,
                         on_error,
                     } => Action::ComputeDeserializeElement {
                         store_in: store_in.clone(),
                         index: id,
                         function: function.clone(),
                         data: data.clone(),
-                        message_name: message_name.clone(),
                         serde_adapter: serde_adapter.clone(),
+                        expected_senders: expected_senders.clone(),
                         on_error: on_error.clone(),
                     },
                 });
@@ -610,10 +614,6 @@ impl<SP: SessionParameters> Ruleset<SP> {
             .or_else(|| self.pop_collect_action())
             .or_else(|| self.pop_mapping_action())
             .or_else(|| self.pop_send_action())
-    }
-
-    pub fn expected_messages(&self) -> &BTreeMap<FullName, BTreeSet<SP::Verifier>> {
-        &self.expected_messages
     }
 
     pub fn arguments(&self) -> &BTreeMap<String, ScalarArgumentTag> {

--- a/ayatori/src/graph_representation/any_node.rs
+++ b/ayatori/src/graph_representation/any_node.rs
@@ -324,9 +324,6 @@ impl<SP: SessionParameters> AnyNode<SP> {
                             match function.call(id, args) {
                                 Ok(_) => Ok(EvidenceVerdict::invalid("The target function finished successfully")),
                                 Err(MaybeAttributableError::Attributable { .. }) => Ok(EvidenceVerdict::valid()),
-                                Err(MaybeAttributableError::Spurious(error)) => {
-                                    Err(UnattributableError::Spurious(error))
-                                }
                                 Err(MaybeAttributableError::Runtime(error)) => Err(UnattributableError::Runtime(error)),
                             }
                             .map(Value::new)

--- a/ayatori/src/graph_representation/any_node.rs
+++ b/ayatori/src/graph_representation/any_node.rs
@@ -20,8 +20,8 @@ use super::{
 use crate::{
     entities::{
         AnyTagRef, AssociatedData, EvidenceVerdict, FullName, MappingTag, MappingTagRef, PartyGroup, RuntimeError,
-        ScalarFunction, ScalarTagRef, SenderAttributableError, SenderAttributableErrorEnum, SimpleMappingFunction,
-        UnattributableError, UnattributableMappingFunction, UnattributableScalarFunction, Value,
+        ScalarFunction, ScalarTagRef, SenderAttributableError, SimpleMappingFunction, UnattributableError,
+        UnattributableMappingFunction, UnattributableScalarFunction, Value,
     },
     error::TraceableResult,
     traits::SessionParameters,
@@ -323,13 +323,11 @@ impl<SP: SessionParameters> AnyNode<SP> {
                         move |id, args| {
                             match function.call(id, args) {
                                 Ok(_) => Ok(EvidenceVerdict::invalid("The target function finished successfully")),
-                                Err(SenderAttributableError(SenderAttributableErrorEnum::Attributable { .. })) => {
-                                    Ok(EvidenceVerdict::valid())
-                                }
-                                Err(SenderAttributableError(SenderAttributableErrorEnum::Spurious(error))) => {
+                                Err(SenderAttributableError::Attributable { .. }) => Ok(EvidenceVerdict::valid()),
+                                Err(SenderAttributableError::Spurious(error)) => {
                                     Err(UnattributableError::Spurious(error))
                                 }
-                                Err(SenderAttributableError(SenderAttributableErrorEnum::Runtime(error))) => {
+                                Err(SenderAttributableError::Runtime(error)) => {
                                     Err(UnattributableError::Runtime(error))
                                 }
                             }

--- a/ayatori/src/graph_representation/any_node.rs
+++ b/ayatori/src/graph_representation/any_node.rs
@@ -347,11 +347,11 @@ impl<SP: SessionParameters> AnyNode<SP> {
         // This is a bit of a hack.
         // To make the node tree suitable for a ruleset generation, the root node must be a scalar computation node.
         // But we cannot just assign a random name to it since there will always be a possiblity of a clash.
-        // So we take the original root name (which is guaranteed to not be present in the subtree),
-        // and use it for the new root.
+        // So we take the original root name (which is guaranteed to not be present in the subtree,
+        // because we cannot build a reproduction subtree for a scalar node), and use it for the new root.
         let AnyTagRef::Scalar(ScalarTagRef::Computed(original_output_tag)) = self.store_in() else {
-            return Err(RuntimeError::expect(
-                "We only get the reproduction subtree from a valid root node",
+            return Err(RuntimeError::new(
+                "Expected the root node to have a `ComputedScalar` tag",
             ));
         };
         let arg_name = "value";

--- a/ayatori/src/graph_representation/any_node.rs
+++ b/ayatori/src/graph_representation/any_node.rs
@@ -23,6 +23,7 @@ use crate::{
         ScalarFunction, ScalarTagRef, SenderAttributableError, SenderAttributableErrorEnum, SimpleMappingFunction,
         UnattributableMappingFunction, UnattributableScalarFunction, Value,
     },
+    error::TraceableResult,
     traits::SessionParameters,
 };
 
@@ -341,7 +342,7 @@ impl<SP: SessionParameters> AnyNode<SP> {
         };
 
         let node =
-            CollectArg::try_from(node.tree_without_dependencies()).expect("the node is convertable to CollectArg");
+            CollectArg::try_from(node.tree_without_dependencies()).expect("the node is convertible to CollectArg");
 
         // The output must be a scalar node, and `node` is a mapping node.
         // So we wrap it in a collect.
@@ -353,8 +354,8 @@ impl<SP: SessionParameters> AnyNode<SP> {
         // So we take the original root name (which is guaranteed to not be present in the subtree),
         // and use it for the new root.
         let AnyTagRef::Scalar(ScalarTagRef::Computed(original_output_tag)) = self.store_in() else {
-            return Err(RuntimeError::new(
-                "Assumption: we only get the reproduction subtree from a valid root node",
+            return Err(RuntimeError::expect(
+                "We only get the reproduction subtree from a valid root node",
             ));
         };
         let arg_name = "value";
@@ -384,7 +385,10 @@ impl<SP: SessionParameters> AnyNode<SP> {
         // The root node will be processed separately
         for node in LeavesFirstIterator::new_with_nodes(self.args_and_dependencies()) {
             let old_id = node.id();
-            let new_node = f(node)?.with_replacements(&replacement_nodes)?;
+            let store_in = node.store_in().to_owned();
+            let new_node = f(node)
+                .or_with_context(|| format!("Failed to apply predicate to the node {store_in}"))?
+                .with_replacements(&replacement_nodes)?;
             // Note that this may lead to errors if the node with `old_id` is dropped,
             // but we are still retaining `self`, so all of its tree will persist until the end of the method.
             if new_node.id() != old_id {
@@ -392,7 +396,9 @@ impl<SP: SessionParameters> AnyNode<SP> {
             }
         }
 
-        f(self.get_strong_ref())?.with_replacements(&replacement_nodes)
+        f(self.get_strong_ref())
+            .or_with_context(|| format!("Failed to apply predicate to the root node {}", self.store_in()))?
+            .with_replacements(&replacement_nodes)
     }
 
     pub(crate) fn tree_with_added_prefix(&self, prefix: &str) -> Self {

--- a/ayatori/src/graph_representation/any_node.rs
+++ b/ayatori/src/graph_representation/any_node.rs
@@ -19,8 +19,8 @@ use super::{
 };
 use crate::{
     entities::{
-        AnyTagRef, AssociatedData, EvidenceVerdict, FullName, MappingTag, MappingTagRef, PartyGroup, RuntimeError,
-        ScalarFunction, ScalarTagRef, SenderAttributableError, SimpleMappingFunction, UnattributableError,
+        AnyTagRef, AssociatedData, EvidenceVerdict, FullName, MappingTag, MappingTagRef, MaybeAttributableError,
+        PartyGroup, RuntimeError, ScalarFunction, ScalarTagRef, SimpleMappingFunction, UnattributableError,
         UnattributableMappingFunction, UnattributableScalarFunction, Value,
     },
     error::TraceableResult,
@@ -323,13 +323,11 @@ impl<SP: SessionParameters> AnyNode<SP> {
                         move |id, args| {
                             match function.call(id, args) {
                                 Ok(_) => Ok(EvidenceVerdict::invalid("The target function finished successfully")),
-                                Err(SenderAttributableError::Attributable { .. }) => Ok(EvidenceVerdict::valid()),
-                                Err(SenderAttributableError::Spurious(error)) => {
+                                Err(MaybeAttributableError::Attributable { .. }) => Ok(EvidenceVerdict::valid()),
+                                Err(MaybeAttributableError::Spurious(error)) => {
                                     Err(UnattributableError::Spurious(error))
                                 }
-                                Err(SenderAttributableError::Runtime(error)) => {
-                                    Err(UnattributableError::Runtime(error))
-                                }
+                                Err(MaybeAttributableError::Runtime(error)) => Err(UnattributableError::Runtime(error)),
                             }
                             .map(Value::new)
                         },

--- a/ayatori/src/graph_representation/any_node.rs
+++ b/ayatori/src/graph_representation/any_node.rs
@@ -21,7 +21,7 @@ use crate::{
     entities::{
         AnyTagRef, AssociatedData, EvidenceVerdict, FullName, MappingTag, MappingTagRef, PartyGroup, RuntimeError,
         ScalarFunction, ScalarTagRef, SenderAttributableError, SenderAttributableErrorEnum, SimpleMappingFunction,
-        UnattributableMappingFunction, UnattributableScalarFunction, Value,
+        UnattributableError, UnattributableMappingFunction, UnattributableScalarFunction, Value,
     },
     error::TraceableResult,
     traits::SessionParameters,
@@ -323,11 +323,14 @@ impl<SP: SessionParameters> AnyNode<SP> {
                         move |id, args| {
                             match function.call(id, args) {
                                 Ok(_) => Ok(EvidenceVerdict::invalid("The target function finished successfully")),
-                                Err(SenderAttributableError(SenderAttributableErrorEnum::Unattributable(error))) => {
-                                    Err(error)
-                                }
                                 Err(SenderAttributableError(SenderAttributableErrorEnum::Attributable { .. })) => {
                                     Ok(EvidenceVerdict::valid())
+                                }
+                                Err(SenderAttributableError(SenderAttributableErrorEnum::Spurious(error))) => {
+                                    Err(UnattributableError::Spurious(error))
+                                }
+                                Err(SenderAttributableError(SenderAttributableErrorEnum::Runtime(error))) => {
+                                    Err(UnattributableError::Runtime(error))
                                 }
                             }
                             .map(Value::new)

--- a/ayatori/src/graph_representation/constructors.rs
+++ b/ayatori/src/graph_representation/constructors.rs
@@ -448,7 +448,7 @@ pub fn direct_message<SP: SessionParameters>(
 fn default_deserialize<SP: SessionParameters>(
     args: &DeserializeArgs<SP>,
 ) -> Result<Value, MaybeAttributableError<SenderError>> {
-    let verified_value = args.verified_value();
+    let verified_value = args.verified_value()?;
 
     let expected_senders = args.expected_senders();
 

--- a/ayatori/src/graph_representation/constructors.rs
+++ b/ayatori/src/graph_representation/constructors.rs
@@ -24,11 +24,11 @@ use crate::{
         EvidenceVerdict, FullName, LocalSignedTag, MergedScalarTag, OneOrBoth, PartyGroup, RemoteSignedTag,
         RuntimeError, ScalarArgumentTag, ScalarFunction, SenderAttributableError, SenderAttributableErrorWithReveal,
         SenderAttributableMappingFunction, SenderAttributableVerificationFunction,
-        SenderAttributableWithRevealMappingFunction, SerdeAdapter, SerializeAndSignFunction, SerializeArgs, SessionId,
-        SignedValue, SimpleMappingFunction, ThirdPartyAttributableError, ThirdPartyAttributableMappingFunction,
-        ThirdPartyAttributableVerificationFunction, UnattributableError, UnattributableMappingFunction,
-        UnattributableMappingFunctionWithRng, UnattributableOptionalScalarFunction, UnattributableScalarFunction,
-        UnattributableScalarFunctionWithRng, Value,
+        SenderAttributableWithRevealMappingFunction, SenderError, SerdeAdapter, SerializeAndSignFunction,
+        SerializeArgs, SessionId, SignedValue, SimpleMappingFunction, ThirdPartyAttributableError,
+        ThirdPartyAttributableMappingFunction, ThirdPartyAttributableVerificationFunction, UnattributableError,
+        UnattributableMappingFunction, UnattributableMappingFunctionWithRng, UnattributableOptionalScalarFunction,
+        UnattributableScalarFunction, UnattributableScalarFunctionWithRng, Value,
     },
     error::TraceableResult,
     traits::{ComposableProtocol, SessionParameters},
@@ -455,16 +455,13 @@ fn default_deserialize<SP: SessionParameters>(args: &DeserializeArgs<SP>) -> Res
     let expected_senders = args.expected_senders();
 
     if !expected_senders.contains(verified_value.source()) {
-        return Err(SenderAttributableError::new(format!(
-            "Expected senders do not include {:?}",
-            verified_value.source()
-        )));
+        return Err(SenderError::new(format!("Expected senders do not include {:?}", verified_value.source())).into());
     }
 
     let value = args
         .serde_adapter()
         .deserialize(verified_value.serialized_value())
-        .map_err(|error| SenderAttributableError::new(format!("Failed to deserialize the value: {error}")))?;
+        .map_err(|error| SenderError::new(format!("Failed to deserialize the value: {error}")))?;
 
     Ok(value)
 }

--- a/ayatori/src/graph_representation/constructors.rs
+++ b/ayatori/src/graph_representation/constructors.rs
@@ -21,14 +21,13 @@ use super::{
 use crate::{
     entities::{
         Args, AssociatedData, ComputedMappingTag, ComputedScalarTag, DeserializeArgs, DeserializeFunction, Erasable,
-        EvidenceVerdict, FullName, LocalSignedTag, MergedScalarTag, OneOrBoth, PartyGroup, RemoteSignedTag,
-        RuntimeError, ScalarArgumentTag, ScalarFunction, SenderAttributableError, SenderAttributableErrorWithReveal,
-        SenderAttributableMappingFunction, SenderAttributableVerificationFunction,
-        SenderAttributableWithRevealMappingFunction, SenderError, SerdeAdapter, SerializeAndSignFunction,
-        SerializeArgs, SessionId, SignedValue, SimpleMappingFunction, ThirdPartyAttributableError,
-        ThirdPartyAttributableMappingFunction, ThirdPartyAttributableVerificationFunction, UnattributableError,
-        UnattributableMappingFunction, UnattributableMappingFunctionWithRng, UnattributableOptionalScalarFunction,
-        UnattributableScalarFunction, UnattributableScalarFunctionWithRng, Value,
+        EvidenceVerdict, FullName, LocalSignedTag, MaybeAttributableError, MergedScalarTag, OneOrBoth, PartyGroup,
+        RemoteSignedTag, RuntimeError, ScalarArgumentTag, ScalarFunction, SenderAttributableMappingFunction,
+        SenderAttributableVerificationFunction, SenderAttributableWithRevealMappingFunction, SenderError,
+        SenderErrorWithReveal, SerdeAdapter, SerializeAndSignFunction, SerializeArgs, SessionId, SignedValue,
+        SimpleMappingFunction, ThirdPartyAttributableMappingFunction, ThirdPartyAttributableVerificationFunction,
+        ThirdPartyError, UnattributableError, UnattributableMappingFunction, UnattributableMappingFunctionWithRng,
+        UnattributableOptionalScalarFunction, UnattributableScalarFunction, UnattributableScalarFunctionWithRng, Value,
     },
     error::TraceableResult,
     traits::{ComposableProtocol, SessionParameters},
@@ -277,7 +276,7 @@ pub fn compute_mapping<SP: SessionParameters, Ret: Erasable>(
 /// caused by the data provided by the party with the ID it is called for.
 pub fn compute_mapping_sender_fallible<SP: SessionParameters, Ret: Erasable>(
     name: &str,
-    function: impl 'static + Send + Sync + Fn(&SP::Verifier, &Args<SP>) -> Result<Ret, SenderAttributableError>,
+    function: impl 'static + Send + Sync + Fn(&SP::Verifier, &Args<SP>) -> Result<Ret, MaybeAttributableError<SenderError>>,
     args: impl Into<ComputeMappingArgs<SP>>,
 ) -> Node<ComputeMapping<SP>> {
     let args: ComputeMappingArgs<SP> = args.into();
@@ -319,7 +318,10 @@ pub fn compute_mapping_with_rng<SP: SessionParameters, Ret: Erasable>(
 /// (that is, not the one which whose ID it is called).
 pub fn compute_mapping_third_party_fallible<SP: SessionParameters, Ret: Erasable>(
     name: &str,
-    function: impl 'static + Send + Sync + Fn(&SP::Verifier, &Args<SP>) -> Result<Ret, ThirdPartyAttributableError<SP>>,
+    function: impl 'static
+    + Send
+    + Sync
+    + Fn(&SP::Verifier, &Args<SP>) -> Result<Ret, MaybeAttributableError<ThirdPartyError<SP>>>,
     args: impl Into<ComputeMappingArgs<SP>>,
     verification: impl 'static
     + Send
@@ -345,7 +347,7 @@ pub fn compute_mapping_sender_fallible_with_reveal<SP: SessionParameters, Ret: E
     function: impl 'static
     + Send
     + Sync
-    + Fn(&SP::Verifier, &Args<SP>) -> Result<Ret, SenderAttributableErrorWithReveal<SP>>,
+    + Fn(&SP::Verifier, &Args<SP>) -> Result<Ret, MaybeAttributableError<SenderErrorWithReveal<SP>>>,
     args: impl Into<ComputeMappingArgs<SP>>,
     verification: impl 'static
     + Send
@@ -449,7 +451,9 @@ pub fn direct_message<SP: SessionParameters>(
     collect(CollectArg::DirectMessage(send_node), group)
 }
 
-fn default_deserialize<SP: SessionParameters>(args: &DeserializeArgs<SP>) -> Result<Value, SenderAttributableError> {
+fn default_deserialize<SP: SessionParameters>(
+    args: &DeserializeArgs<SP>,
+) -> Result<Value, MaybeAttributableError<SenderError>> {
     let verified_value = args.verified_value();
 
     let expected_senders = args.expected_senders();

--- a/ayatori/src/graph_representation/constructors.rs
+++ b/ayatori/src/graph_representation/constructors.rs
@@ -390,14 +390,13 @@ fn default_serialize_and_sign<SP: SessionParameters>(
     Ok(Value::new(signed_value))
 }
 
-/// Broadcasts the scalar data with the type and name defined by `message` to all the nodes from `group`.
+/// Broadcasts the scalar data with the type and name defined by `message`.
 ///
-/// The return values are the collected outcomes of messages being sent (`()` on success).
+/// The target nodes are determined by the group this mapping is collected into.
 pub fn broadcast<SP: SessionParameters>(
     message: &ProtocolMessage<SP>,
     scalar: impl Into<BroadcastArg<SP>>,
-    group: &PartyGroup<SP::Verifier>,
-) -> Node<Collect<SP>> {
+) -> Node<DirectMessage<SP>> {
     let scalar: BroadcastArg<SP> = scalar.into();
     let signed_tag = LocalSignedTag::new(message.name());
     let sent_tag = signed_tag.to_sent();
@@ -411,24 +410,21 @@ pub fn broadcast<SP: SessionParameters>(
         dependencies: Vec::new(),
     });
 
-    let send_node = Node::new(DirectMessage {
+    Node::new(DirectMessage {
         store_in: sent_tag,
         data: serialize_and_sign,
         dependencies: Vec::new(),
-    });
-
-    collect(CollectArg::DirectMessage(send_node), group)
+    })
 }
 
-/// Sends a direct message with the corresponding element from the given mapping,
-/// and with the type and name defined by `message`, to all the nodes from `group`.
+/// Sends a direct message with the corresponding element from the given mapping.,
+/// and with the type and name defined by `message`.
 ///
-/// The return values are the collected outcomes of messages being sent (`()` on success).
+/// The target nodes are determined by the group this mapping is collected into.
 pub fn direct_message<SP: SessionParameters>(
     message: &ProtocolMessage<SP>,
     data: impl Into<DirectMessageArg<SP>>,
-    group: &PartyGroup<SP::Verifier>,
-) -> Node<Collect<SP>> {
+) -> Node<DirectMessage<SP>> {
     let data: DirectMessageArg<SP> = data.into();
     let signed_tag = LocalSignedTag::new(message.name());
     let sent_tag = signed_tag.to_sent();
@@ -442,13 +438,11 @@ pub fn direct_message<SP: SessionParameters>(
         dependencies: Vec::new(),
     });
 
-    let send_node = Node::new(DirectMessage {
+    Node::new(DirectMessage {
         store_in: sent_tag,
         data: serialize_and_sign,
         dependencies: Vec::new(),
-    });
-
-    collect(CollectArg::DirectMessage(send_node), group)
+    })
 }
 
 fn default_deserialize<SP: SessionParameters>(

--- a/ayatori/src/graph_representation/constructors.rs
+++ b/ayatori/src/graph_representation/constructors.rs
@@ -30,6 +30,7 @@ use crate::{
         UnattributableMappingFunctionWithRng, UnattributableOptionalScalarFunction, UnattributableScalarFunction,
         UnattributableScalarFunctionWithRng, Value,
     },
+    error::TraceableResult,
     traits::{ComposableProtocol, SessionParameters},
 };
 
@@ -371,7 +372,10 @@ fn default_serialize_and_sign<SP: SessionParameters>(
     destination: &SP::Verifier,
     args: &SerializeArgs<SP>,
 ) -> Result<Value, RuntimeError> {
-    let serialized_value = args.serde_adapter().serialize(args.value())?;
+    let serialized_value = args
+        .serde_adapter()
+        .serialize(args.value())
+        .or_with_context(|| format!("Failed to serialize an outgoing value `{}`", args.message_name()))?;
     let signed_value = SignedValue::<SP>::new(
         rng,
         args.signer(),
@@ -379,7 +383,8 @@ fn default_serialize_and_sign<SP: SessionParameters>(
         args.message_name(),
         destination,
         serialized_value,
-    )?;
+    )
+    .or_with_context(|| format!("Failed to sign an outgoing value `{}`", args.message_name()))?;
     Ok(Value::new(signed_value))
 }
 
@@ -533,10 +538,13 @@ pub fn call_protocol<SP: SessionParameters, P: ComposableProtocol<SP>>(
 ) -> Result<P::OutputNode, RuntimeError> {
     let signature = P::signature();
     let arg_nodes = ArgNodes::new(&signature);
-    let output = P::build(party_build_data, build_data, arg_nodes)?;
+    let output = P::build(party_build_data, build_data, arg_nodes)
+        .or_with_context(|| "Failed to build the protocol graph".into())?;
     let any_node = Into::<AnyNode<SP>>::into(output).get_strong_ref();
     let prefixed = any_node.tree_with_added_prefix(prefix);
-    let bound_args = signature.bind(args)?;
+    let bound_args = signature
+        .bind(args)
+        .or_with_context(|| "Failed to bind protocol arguments".into())?;
     let with_args = prefixed.with_substituted_arguments(&bound_args)?;
     let downcasted = P::OutputNode::try_from(with_args)
         .map_err(|_err| RuntimeError::new("Adding a prefix changed the root node type"))?;

--- a/ayatori/src/graph_representation/typed_nodes.rs
+++ b/ayatori/src/graph_representation/typed_nodes.rs
@@ -24,6 +24,7 @@ use crate::{
         SerializeAndSignFunction, SimpleMappingFunction, ThirdPartyAttributableMappingFunction,
         ThirdPartyAttributableVerificationFunction,
     },
+    error::TraceableResult,
     traits::SessionParameters,
 };
 
@@ -184,8 +185,14 @@ impl<SP: SessionParameters> SpecificNode<SP> for ComputeScalar<SP> {
 
     fn with_replacements(self, replacements: &BTreeMap<usize, AnyNode<SP>>) -> Result<Self, RuntimeError> {
         let mut node = self;
-        replace_in_btreemap(&mut node.args, replacements)?;
-        replace_in_slice(&mut node.dependencies, replacements)?;
+        replace_in_btreemap(&mut node.args, replacements)
+            .or_with_context(|| format!("Failed to replace nodes in the arguments of node `{}`", node.store_in))?;
+        replace_in_slice(&mut node.dependencies, replacements).or_with_context(|| {
+            format!(
+                "Failed to replace nodes in the dependencies of node `{}`",
+                node.store_in
+            )
+        })?;
         Ok(node)
     }
 }
@@ -245,8 +252,14 @@ impl<SP: SessionParameters> SpecificNode<SP> for Collect<SP> {
 
     fn with_replacements(self, replacements: &BTreeMap<usize, AnyNode<SP>>) -> Result<Self, RuntimeError> {
         let mut node = self;
-        replace_in_node(&mut node.values, replacements)?;
-        replace_in_slice(&mut node.dependencies, replacements)?;
+        replace_in_node(&mut node.values, replacements)
+            .or_with_context(|| format!("Failed to replace nodes in the argument of node `{}`", node.store_in))?;
+        replace_in_slice(&mut node.dependencies, replacements).or_with_context(|| {
+            format!(
+                "Failed to replace nodes in the dependencies of node `{}`",
+                node.store_in
+            )
+        })?;
         Ok(node)
     }
 }
@@ -283,7 +296,7 @@ pub(crate) enum ComputeMappingKind<SP: SessionParameters> {
 }
 
 impl<SP: SessionParameters> ComputeMappingKind<SP> {
-    pub(crate) fn shallow_clone(&self) -> Self {
+    fn shallow_clone(&self) -> Self {
         match self {
             Self::Simple { function } => Self::Simple {
                 function: function.clone(),
@@ -304,12 +317,18 @@ impl<SP: SessionParameters> ComputeMappingKind<SP> {
         }
     }
 
-    pub(crate) fn with_replacements(self, replacements: &BTreeMap<usize, AnyNode<SP>>) -> Result<Self, RuntimeError> {
+    fn with_replacements(
+        self,
+        store_in: &ComputedMappingTag,
+        replacements: &BTreeMap<usize, AnyNode<SP>>,
+    ) -> Result<Self, RuntimeError> {
         let mut kind = self;
         match &mut kind {
             Self::Simple { .. } | Self::ThirdPartyAttributable { .. } => {}
             Self::WithReveal { verification_args, .. } => {
-                replace_in_btreemap(verification_args, replacements)?;
+                replace_in_btreemap(verification_args, replacements).or_with_context(|| {
+                    format!("Failed to replace nodes in the verification arguments of node `{store_in}`")
+                })?;
             }
         }
         Ok(kind)
@@ -345,9 +364,15 @@ impl<SP: SessionParameters> SpecificNode<SP> for ComputeMapping<SP> {
 
     fn with_replacements(self, replacements: &BTreeMap<usize, AnyNode<SP>>) -> Result<Self, RuntimeError> {
         let mut node = self;
-        replace_in_btreemap(&mut node.args, replacements)?;
-        node.kind = node.kind.with_replacements(replacements)?;
-        replace_in_slice(&mut node.dependencies, replacements)?;
+        replace_in_btreemap(&mut node.args, replacements)
+            .or_with_context(|| format!("Failed to replace nodes in the arguments of node `{}`", node.store_in))?;
+        node.kind = node.kind.with_replacements(&node.store_in, replacements)?;
+        replace_in_slice(&mut node.dependencies, replacements).or_with_context(|| {
+            format!(
+                "Failed to replace nodes in the dependencies of node `{}`",
+                node.store_in
+            )
+        })?;
         Ok(node)
     }
 }
@@ -412,8 +437,14 @@ impl<SP: SessionParameters> SpecificNode<SP> for SerializeAndSign<SP> {
 
     fn with_replacements(self, replacements: &BTreeMap<usize, AnyNode<SP>>) -> Result<Self, RuntimeError> {
         let mut node = self;
-        replace_in_node(&mut node.data, replacements)?;
-        replace_in_slice(&mut node.dependencies, replacements)?;
+        replace_in_node(&mut node.data, replacements)
+            .or_with_context(|| format!("Failed to replace nodes in the argument of node `{}`", node.store_in))?;
+        replace_in_slice(&mut node.dependencies, replacements).or_with_context(|| {
+            format!(
+                "Failed to replace nodes in the dependencies of node `{}`",
+                node.store_in
+            )
+        })?;
         Ok(node)
     }
 }
@@ -478,8 +509,14 @@ impl<SP: SessionParameters> SpecificNode<SP> for DeserializeAndCheck<SP> {
 
     fn with_replacements(self, replacements: &BTreeMap<usize, AnyNode<SP>>) -> Result<Self, RuntimeError> {
         let mut node = self;
-        replace_in_node(&mut node.data, replacements)?;
-        replace_in_slice(&mut node.dependencies, replacements)?;
+        replace_in_node(&mut node.data, replacements)
+            .or_with_context(|| format!("Failed to replace nodes in the argument of node `{}`", node.store_in))?;
+        replace_in_slice(&mut node.dependencies, replacements).or_with_context(|| {
+            format!(
+                "Failed to replace nodes in the dependencies of node `{}`",
+                node.store_in
+            )
+        })?;
         Ok(node)
     }
 }
@@ -537,8 +574,14 @@ impl<SP: SessionParameters> SpecificNode<SP> for DirectMessage<SP> {
 
     fn with_replacements(self, replacements: &BTreeMap<usize, AnyNode<SP>>) -> Result<Self, RuntimeError> {
         let mut node = self;
-        replace_in_node(&mut node.data, replacements)?;
-        replace_in_slice(&mut node.dependencies, replacements)?;
+        replace_in_node(&mut node.data, replacements)
+            .or_with_context(|| format!("Failed to replace nodes in the argument of node `{}`", node.store_in))?;
+        replace_in_slice(&mut node.dependencies, replacements).or_with_context(|| {
+            format!(
+                "Failed to replace nodes in the dependencies of node `{}`",
+                node.store_in
+            )
+        })?;
         Ok(node)
     }
 }
@@ -586,7 +629,12 @@ impl<SP: SessionParameters> SpecificNode<SP> for Receive<SP> {
 
     fn with_replacements(self, replacements: &BTreeMap<usize, AnyNode<SP>>) -> Result<Self, RuntimeError> {
         let mut node = self;
-        replace_in_slice(&mut node.dependencies, replacements)?;
+        replace_in_slice(&mut node.dependencies, replacements).or_with_context(|| {
+            format!(
+                "Failed to replace nodes in the dependencies of node `{}`",
+                node.store_in
+            )
+        })?;
         Ok(node)
     }
 }
@@ -675,8 +723,18 @@ impl<SP: SessionParameters> SpecificNode<SP> for MergeScalars<SP> {
 
     fn with_replacements(self, replacements: &BTreeMap<usize, AnyNode<SP>>) -> Result<Self, RuntimeError> {
         let mut node = self;
-        replace_in_node(&mut node.left, replacements)?;
-        replace_in_node(&mut node.right, replacements)?;
+        replace_in_node(&mut node.left, replacements).or_with_context(|| {
+            format!(
+                "Failed to replace nodes in the left argument of node `{}`",
+                node.store_in
+            )
+        })?;
+        replace_in_node(&mut node.right, replacements).or_with_context(|| {
+            format!(
+                "Failed to replace nodes in the right argument of node `{}`",
+                node.store_in
+            )
+        })?;
         Ok(node)
     }
 }

--- a/ayatori/src/graph_representation/unions.rs
+++ b/ayatori/src/graph_representation/unions.rs
@@ -15,8 +15,11 @@ use crate::protocol_author_api::Args;
 
 /// An error returned when attempting to downcast from a larger union type to a smaller one (or a single type),
 /// and the variant of the larger union is not present in the smalle one.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, displaydoc::Display)]
+#[displaydoc("Failed to narrow down a union")]
 pub struct UnionCastError;
+
+impl core::error::Error for UnionCastError {}
 
 /// Possible arguments to a [`ComputeScalar`] node.
 #[derive_where::derive_where(Debug)]

--- a/ayatori/src/lib.rs
+++ b/ayatori/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate alloc;
 
 mod entities;
+mod error;
 mod execution;
 mod flat_representation;
 mod graph_representation;

--- a/ayatori/src/protocol_author_api.rs
+++ b/ayatori/src/protocol_author_api.rs
@@ -3,9 +3,9 @@
 pub use crate::{
     entities::{
         Args, AssociatedData, Erasable, EvidenceVerdict, FullName, OneOrBoth, PartyGroup, RuntimeError,
-        SenderAttributableError, SenderAttributableErrorWithReveal, SerdeAdapter, SerializeArgs, SerializedValue,
-        SessionId, SignedHash, SignedValue, SpuriousError, ThirdPartyAttributableError, UnattributableError,
-        ValueMetadata, VerificationError, VerifiedValue,
+        SenderAttributableError, SenderAttributableErrorWithReveal, SenderError, SenderErrorWithReveal, SerdeAdapter,
+        SerializeArgs, SerializedValue, SessionId, SignedHash, SignedValue, SpuriousError, ThirdPartyAttributableError,
+        ThirdPartyError, UnattributableError, ValueMetadata, VerificationError, VerifiedValue,
     },
     graph_representation::{
         AnyNode, ArgNodes, BroadcastArg, Collect, CollectArg, ComputeMapping, ComputeMappingArg, ComputeMappingArgs,

--- a/ayatori/src/protocol_author_api.rs
+++ b/ayatori/src/protocol_author_api.rs
@@ -2,10 +2,10 @@
 
 pub use crate::{
     entities::{
-        Args, AssociatedData, Erasable, EvidenceVerdict, FullName, OneOrBoth, PartyGroup, RuntimeError,
-        SenderAttributableError, SenderAttributableErrorWithReveal, SenderError, SenderErrorWithReveal, SerdeAdapter,
-        SerializeArgs, SerializedValue, SessionId, SignedHash, SignedValue, SpuriousError, ThirdPartyAttributableError,
-        ThirdPartyError, UnattributableError, ValueMetadata, VerificationError, VerifiedValue,
+        Args, AssociatedData, Erasable, EvidenceVerdict, FullName, MaybeAttributableError, OneOrBoth, PartyGroup,
+        RuntimeError, SenderError, SenderErrorWithReveal, SerdeAdapter, SerializeArgs, SerializedValue, SessionId,
+        SignedHash, SignedValue, SpuriousError, ThirdPartyError, UnattributableError, ValueMetadata, VerificationError,
+        VerifiedValue,
     },
     graph_representation::{
         AnyNode, ArgNodes, BroadcastArg, Collect, CollectArg, ComputeMapping, ComputeMappingArg, ComputeMappingArgs,

--- a/ayatori/src/protocol_user_api.rs
+++ b/ayatori/src/protocol_user_api.rs
@@ -4,7 +4,7 @@ pub use crate::{
     entities::{Message, MessageId, PartyGroup, RuntimeError, SessionId, SpuriousError},
     execution::{
         DuplicateMessagesError, Evidence, InvalidMessageError, MessageAttributableError, ReachedOutputSession, Session,
-        SessionOutcome, SessionReport, SessionState, Task,
+        SessionOutcome, SessionReport, SessionState, Task, UnfinishableOutcome,
     },
     traits::{ExecutableProtocol, SessionParameters},
 };

--- a/ayatori/src/protocol_user_api.rs
+++ b/ayatori/src/protocol_user_api.rs
@@ -4,7 +4,7 @@ pub use crate::{
     entities::{Message, MessageId, PartyGroup, RuntimeError, SessionId, SpuriousError},
     execution::{
         DuplicateMessagesError, Evidence, InvalidMessageError, MessageAttributableError, ReachedOutputSession, Session,
-        SessionError, SessionReport, SessionState, StalledSession, Task, TaskError,
+        SessionOutcome, SessionReport, SessionState, Task,
     },
     traits::{ExecutableProtocol, SessionParameters},
 };

--- a/ayatori/src/protocol_user_api.rs
+++ b/ayatori/src/protocol_user_api.rs
@@ -1,10 +1,10 @@
 //! The API to be used by the code that executes the protocol.
 
 pub use crate::{
-    entities::{Message, MessageId, PartyGroup, RuntimeError, SessionId, UnattributableError},
+    entities::{Message, MessageId, PartyGroup, RuntimeError, SessionId, SpuriousError},
     execution::{
         DuplicateMessagesError, Evidence, InvalidMessageError, MessageAttributableError, ReachedOutputSession, Session,
-        SessionReport, SessionState, StalledSession, Task, TaskError,
+        SessionError, SessionReport, SessionState, StalledSession, Task, TaskError,
     },
     traits::{ExecutableProtocol, SessionParameters},
 };

--- a/book-examples/rustfmt.toml
+++ b/book-examples/rustfmt.toml
@@ -1,2 +1,2 @@
-max_width = 90
+max_width = 86
 edition = "2024"

--- a/book-examples/src/distributed_rng.rs
+++ b/book-examples/src/distributed_rng.rs
@@ -72,23 +72,22 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for DistributedRng {
 
         // ANCHOR: build-send-c
         let message_c = ProtocolMessage::new::<u32>("c");
-        let c_broadcasted = broadcast(&message_c, &my_c, all_parties);
+        let c_broadcasted = broadcast(&message_c, &my_c);
         let c = receive(&message_c);
         // ANCHOR_END: build-send-c
 
         // ANCHOR: build-collect-c
-        let all_c = collect(&c, all_parties).with_dependency(&c_broadcasted);
+        let all_c = collect(&c, all_parties)
+            .with_dependency(&collect(&c_broadcasted, all_parties));
         // ANCHOR_END: build-collect-c
 
         // ANCHOR: build-send-b-r
         let message_b = ProtocolMessage::new::<u32>("b");
-        let b_broadcasted =
-            broadcast(&message_b, &my_b, all_parties).with_dependency(&all_c);
+        let b_broadcasted = broadcast(&message_b, &my_b).with_dependency(&all_c);
         let b = receive(&message_b);
 
         let message_r = ProtocolMessage::new::<u32>("r");
-        let r_broadcasted =
-            broadcast(&message_r, &my_r, all_parties).with_dependency(&all_c);
+        let r_broadcasted = broadcast(&message_r, &my_r).with_dependency(&all_c);
         let r = receive(&message_r);
         // ANCHOR_END: build-send-b-r
 
@@ -116,9 +115,9 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for DistributedRng {
 
         // ANCHOR: build-finalize
         let all_commitments_correct = collect(&commitment_correct, all_parties)
-            .with_dependency(&b_broadcasted)
-            .with_dependency(&r_broadcasted);
-        let all_b = collect(&b, all_parties).with_dependency(&b_broadcasted);
+            .with_dependency(&collect(&b_broadcasted, all_parties))
+            .with_dependency(&collect(&r_broadcasted, all_parties));
+        let all_b = collect(&b, all_parties);
         let output = compute_scalar(
             "output",
             |args| {
@@ -177,7 +176,8 @@ mod tests {
 
     use ayatori::{
         dev::{
-            BinaryFormat, Replacement, TestSessionParams, TestSigner, run_sessions_sync,
+            BinaryFormat, Replacement, TestSessionParams, TestSigner,
+            run_sessions_sync,
         },
         protocol_user_api::*,
     };
@@ -206,7 +206,8 @@ mod tests {
         let sessions = signers
             .into_iter()
             .map(|signer| {
-                S::new(session_id.clone(), signer, &private_data, &shared_data).unwrap()
+                S::new(session_id.clone(), signer, &private_data, &shared_data)
+                    .unwrap()
             })
             .collect::<Vec<_>>();
         let results = run_sessions_sync(&mut rng, sessions).unwrap();
@@ -261,7 +262,10 @@ mod tests {
         let results = run_sessions_sync(&mut rng, sessions).unwrap();
 
         let report1 = &results.reports[&ids[0]];
-        assert!(report1.success_ref().is_some());
+        assert!(matches!(
+            report1.outcome,
+            SessionOutcome::ManuallyTerminated
+        ));
         assert!(report1.provable_errors.is_empty());
 
         // ANCHOR: test_report

--- a/book-examples/src/distributed_rng.rs
+++ b/book-examples/src/distributed_rng.rs
@@ -107,7 +107,7 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for DistributedRng {
                 if b + r == *c {
                     Ok(())
                 } else {
-                    Err(SenderAttributableError::new("b + r != c"))
+                    Err(SenderError::new("b + r != c").into())
                 }
             },
             &[("c", (&c).into()), ("b", (&b).into()), ("r", (&r).into())],

--- a/book-examples/src/distributed_rng.rs
+++ b/book-examples/src/distributed_rng.rs
@@ -270,7 +270,7 @@ mod tests {
 
         // ANCHOR: test_report
         let report2 = &results.reports[&ids[1]];
-        assert!(report2.is_unfinishable());
+        assert!(matches!(report2.outcome, SessionOutcome::Unfinishable(..)));
         let evidence = &report2.provable_errors[&ids[0]];
         assert!(
             evidence
@@ -281,7 +281,7 @@ mod tests {
         // ANCHOR_END: test_report
 
         let report3 = &results.reports[&ids[1]];
-        assert!(report3.is_unfinishable());
+        assert!(matches!(report3.outcome, SessionOutcome::Unfinishable(..)));
         let evidence = &report3.provable_errors[&ids[0]];
         assert!(
             evidence

--- a/book-examples/src/session_runner.rs
+++ b/book-examples/src/session_runner.rs
@@ -3,8 +3,8 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use ayatori::protocol_user_api::{
-    ExecutableProtocol, Session, SessionParameters, SessionReport, SessionState, Task,
-    TaskError, UnattributableError,
+    ExecutableProtocol, Session, SessionError, SessionParameters, SessionReport,
+    SessionState, Task, TaskError,
     tokio::{MessageIn, MessageOut},
 };
 
@@ -15,7 +15,7 @@ pub async fn run_session<SP, P>(
     rx: &mut mpsc::Receiver<MessageIn<SP>>,
     cancellation: CancellationToken,
     mut session: Session<SP, P>,
-) -> Result<SessionReport<SP, P>, UnattributableError>
+) -> Result<SessionReport<SP, P>, SessionError>
 where
     SP: SessionParameters,
     P: ExecutableProtocol<SP>,
@@ -51,7 +51,8 @@ where
             // ANCHOR: task_result
             match task_result {
                 Ok(()) => {}
-                Err(TaskError::Unattributable(error)) => return Err(error),
+                Err(TaskError::Runtime(error)) => return Err(error.into()),
+                Err(TaskError::Spurious(error)) => return Err(error.into()),
                 Err(TaskError::MessageAttributable(error)) => {
                     tx.send(MessageOut::Error(error)).await.unwrap();
                 }

--- a/book-examples/src/session_runner.rs
+++ b/book-examples/src/session_runner.rs
@@ -30,13 +30,13 @@ where
         while let Some(task) = session.make_task()? {
             let task_result = match task {
                 // ANCHOR_END: task_loop
-                // ANCHOR: task_compute
-                Task::Compute(task) => session.add_result(task.execute()),
-                // ANCHOR_END: task_compute
+                // ANCHOR: task_deterministic
+                Task::Deterministic(task) => session.add_result(task.execute()),
+                // ANCHOR_END: task_deterministic
 
-                // ANCHOR: task_compute_rng
-                Task::ComputeWithRng(task) => session.add_result(task.execute(rng)),
-                // ANCHOR_END: task_compute_rng
+                // ANCHOR: task_randomized
+                Task::Randomized(task) => session.add_result(task.execute(rng)),
+                // ANCHOR_END: task_randomized
 
                 // ANCHOR: task_send
                 Task::Send(task) => {

--- a/book-examples/src/session_runner.rs
+++ b/book-examples/src/session_runner.rs
@@ -31,16 +31,16 @@ where
             let task_result = match task {
                 // ANCHOR_END: task_loop
                 // ANCHOR: task_compute
-                Task::Compute(task) => session.add_result(task.compute()),
+                Task::Compute(task) => session.add_result(task.execute()),
                 // ANCHOR_END: task_compute
 
                 // ANCHOR: task_compute_rng
-                Task::ComputeWithRng(task) => session.add_result(task.compute(rng)),
+                Task::ComputeWithRng(task) => session.add_result(task.execute(rng)),
                 // ANCHOR_END: task_compute_rng
 
                 // ANCHOR: task_send
                 Task::Send(task) => {
-                    let (message, result) = task.compute();
+                    let (message, result) = task.execute();
                     if let Some(message) = message {
                         tx.send(MessageOut::Message(message)).await.unwrap();
                     }

--- a/book-examples/src/session_runner.rs
+++ b/book-examples/src/session_runner.rs
@@ -3,8 +3,8 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use ayatori::protocol_user_api::{
-    ExecutableProtocol, Session, SessionError, SessionParameters, SessionReport,
-    SessionState, Task, TaskError,
+    ExecutableProtocol, RuntimeError, Session, SessionParameters, SessionReport,
+    SessionState, Task,
     tokio::{MessageIn, MessageOut},
 };
 
@@ -15,7 +15,7 @@ pub async fn run_session<SP, P>(
     rx: &mut mpsc::Receiver<MessageIn<SP>>,
     cancellation: CancellationToken,
     mut session: Session<SP, P>,
-) -> Result<SessionReport<SP, P>, SessionError>
+) -> Result<SessionReport<SP, P>, RuntimeError>
 where
     SP: SessionParameters,
     P: ExecutableProtocol<SP>,
@@ -28,7 +28,7 @@ where
 
         // ANCHOR: task_loop
         while let Some(task) = session.make_task()? {
-            let task_result = match task {
+            let new_state = match task {
                 // ANCHOR_END: task_loop
                 // ANCHOR: task_deterministic
                 Task::Deterministic(task) => session.add_result(task.execute()),
@@ -49,30 +49,28 @@ where
             };
 
             // ANCHOR: task_result
-            match task_result {
-                Ok(()) => {}
-                Err(TaskError::Runtime(error)) => return Err(error.into()),
-                Err(TaskError::Spurious(error)) => return Err(error.into()),
-                Err(TaskError::MessageAttributable(error)) => {
+            session = match new_state? {
+                // ANCHOR_END: task_result
+                // ANCHOR: task_result_in_progress
+                SessionState::InProgress(session) => session,
+                // ANCHOR_END: task_result_in_progress
+                // ANCHOR: task_result_message_error
+                SessionState::InProgressWithMessageError { error, session } => {
                     tx.send(MessageOut::Error(error)).await.unwrap();
+                    session
                 }
+                // ANCHOR_END: task_result_message_error
+                // ANCHOR: task_result_reached_output
+                SessionState::ReachedOutput(success) => {
+                    return success.finalize();
+                }
+                // ANCHOR_END: task_result_reached_output
+                // ANCHOR: task_result_unfinishable
+                SessionState::Unfinishable(report) => {
+                    return Ok(report);
+                } // ANCHOR_END: task_result_unfinishable
             }
-            // ANCHOR_END: task_result
         }
-
-        // ANCHOR: try_finalize
-        session = match session.try_finalize() {
-            // ANCHOR_END: try_finalize
-            // ANCHOR: try_finalize_in_progress
-            SessionState::InProgress(session) => session,
-            // ANCHOR_END: try_finalize_in_progress
-            // ANCHOR: try_finalize_reached_output
-            SessionState::ReachedOutput(success) => return Ok(success.finalize()?),
-            // ANCHOR_END: try_finalize_reached_output
-            // ANCHOR: try_finalize_stalled
-            SessionState::Stalled(stalled) => return Ok(stalled.finalize()),
-            // ANCHOR_END: try_finalize_stalled
-        };
 
         // ANCHOR: get_message
         let message_in = tokio::select! {
@@ -82,7 +80,9 @@ where
 
         match message_in {
             MessageIn::Message { message, id } => session.add_message(&id, message),
-            MessageIn::Ban { id, reason } => session.register_banned_party(id, reason),
+            MessageIn::Ban { id, reason } => {
+                session.register_banned_party(id, reason)
+            }
         }
         // ANCHOR_END: get_message
     }
@@ -93,7 +93,9 @@ mod tests {
     use alloc::vec::Vec;
 
     use ayatori::{
-        dev::{BinaryFormat, TestSessionParams, TestSigner, tokio::run_sessions_async},
+        dev::{
+            BinaryFormat, TestSessionParams, TestSigner, tokio::run_sessions_async,
+        },
         protocol_user_api::{PartyGroup, Session, SessionId},
     };
     use rand_chacha::ChaCha8Rng;

--- a/book/src/running_a_protocol.md
+++ b/book/src/running_a_protocol.md
@@ -29,14 +29,15 @@ The whole body of the function is an event loop.
 {{#include ../../book-examples/src/session_runner.rs:event_loop}}
 ```
 In it, we will repeatedly perform the following actions:
-- Drain all the available tasks and execute them;
-- Check if the session is finalizable (if it is, exit the loop);
-- Get incoming messages from the channel and pass them to the session.
+- Get a task from the session;
+- Execute the task;
+- Depending on the new session state finalize it or continue;
+- When there are no more tasks, get incoming messages from the channel and pass them to the session.
 
 
 ### Processing tasks
 
-In an inner loop, we will get tasks from the session until there are any.
+In an inner loop, we will get tasks from the session while there are any.
 ```rust,ignore
 {{#include ../../book-examples/src/session_runner.rs:task_loop}}
 ```
@@ -60,43 +61,43 @@ We extract these tasks to their own variant because offloading such tasks to ano
 ```
 This tasks requests that the user sends the message in the task.
 The destination can be obtained from [`Message::destination()`](protocol_user_api::Message::destination) method.
+`message` can be `None` if there has been some error serializing or signing a message; the error will be reported via `result` to be processed in the host thread.
+
 Note that the destination will be the party's public key; matching it to the address for the transport layer (e.g., an IP address) is the user's responsibility.
 We are also pushing to the channel not a [`Message`](protocol_user_api::Message) itself, but a [`MessageOut`](protocol_user_api::tokio::MessageOut) wrapper, because we use the same channel to report non-fatal errors (e.g. malformed messages), as will be illustrated below.
 
-Incorporating the result of a task back into the session may result in a message-attributable error, which we report to the same outgoing channel:
+
+### Processing the task result
+
+After the task is executed, its result needs to be incorporated back into the session.
+This consumes the session object and may return it back, or finalize the session, depending on the result.
 ```rust,ignore
 {{#include ../../book-examples/src/session_runner.rs:task_result}}
 ```
+
+The most common variant is the result having been successfully stored, and the session is still in progress:
+```rust,ignore
+{{#include ../../book-examples/src/session_runner.rs:task_result_in_progress}}
+```
+
+If there was a message-attributable error, we report it to the same outgoing channel:
+```rust,ignore
+{{#include ../../book-examples/src/session_runner.rs:task_result_message_error}}
+```
 The error contains IDs of offending messages which the calling code may use to identify offending parties, if the chosen transport method allows it.
-Message IDs are sent with incoming messages, as shown in the next snippet.
-
-
-### Attempting to finalize
+Message IDs are sent with incoming messages, as will be demonstrated later.
 
 ```rust,ignore
-{{#include ../../book-examples/src/session_runner.rs:try_finalize}}
-```
-Here we attempt to finalize the session.
-Note that the method consumes the session object.
-
-```rust,ignore
-{{#include ../../book-examples/src/session_runner.rs:try_finalize_in_progress}}
-```
-If the session is in progress, we will receive back the session object.
-This means we continue on with the event loop.
-
-```rust,ignore
-{{#include ../../book-examples/src/session_runner.rs:try_finalize_reached_output}}
+{{#include ../../book-examples/src/session_runner.rs:task_result_reached_output}}
 ```
 This means that the output slot has been filled.
 We can now [`finalize()`](protocol_user_api::ReachedOutputSession::finalize) returning the output, but it is also possible to continue on with the loop, accumulating more information.
 This can be important for protocols with threshold conditions, and it is a decision the calling code must make.
 
 ```rust,ignore
-{{#include ../../book-examples/src/session_runner.rs:try_finalize_stalled}}
+{{#include ../../book-examples/src/session_runner.rs:task_result_unfinishable}}
 ```
-This signals that the session cannot possibly reach the result (generally, because some nodes committed malicious actions and were banned, making some collect nodes unreachable), and can thus be finalized.
-Again, the calling code can make the decision to continue on with the loop, potentially accumulating more reports of malicious actions of other nodes.
+This signals that the session cannot possibly reach the result (generally, because some nodes committed malicious actions and were banned, making some collect nodes unreachable), and thus has to be finalized.
 
 
 ### Receiving messages

--- a/book/src/running_a_protocol.md
+++ b/book/src/running_a_protocol.md
@@ -43,14 +43,14 @@ In an inner loop, we will get tasks from the session until there are any.
 Depending on the task, we need to perform certain actions.
 
 ```rust,ignore
-{{#include ../../book-examples/src/session_runner.rs:task_compute}}
+{{#include ../../book-examples/src/session_runner.rs:task_deterministic}}
 ```
 A computation task: execute and give the result back to the session.
 This corresponds to a computation node in the protocol graph.
 Note that it can be offloaded to another `tokio` task, or a thread pool.
 
 ```rust,ignore
-{{#include ../../book-examples/src/session_runner.rs:task_compute_rng}}
+{{#include ../../book-examples/src/session_runner.rs:task_randomized}}
 ```
 This is similar to the computation task above, but this one takes an RNG.
 We extract these tasks to their own variant because offloading such tasks to another threads requires forking an RNG, and it is not trivial.

--- a/book/src/writing_a_protocol.md
+++ b/book/src/writing_a_protocol.md
@@ -190,7 +190,7 @@ which translates to
 {{#include ../../book-examples/src/distributed_rng.rs:build-check-commitment}}
 ```
 When for some ID, `b[ID]`, `r[ID]`, and `c[ID]` are available, the closure will be called with the arguments `b`, `r`, and `c` set to these values.
-If the check fails, we return a new [`SenderAttributableError`](protocol_author_api::SenderAttributableError), because the party that sent mismatched values is at fault.
+If the check fails, we return a new [`SenderError`](protocol_author_api::SenderError), because the party that sent mismatched values is at fault.
 
 Note that if an error is returned, the result is *not* saved to `commitment_correct`, and therefore the following `collect` will never be able to execute (since it requires elements from all parties).
 The execution environment can detect it, and terminate the execution with the corresponding status.

--- a/integration-tests/src/distributed_rng.rs
+++ b/integration-tests/src/distributed_rng.rs
@@ -37,7 +37,7 @@ fn verify_commitment<SP: SessionParameters>(
     if b + r == *c {
         Ok(())
     } else {
-        Err(SenderAttributableError::new("b + r != c"))
+        Err(SenderError::new("b + r != c").into())
     }
 }
 

--- a/integration-tests/src/distributed_rng.rs
+++ b/integration-tests/src/distributed_rng.rs
@@ -89,11 +89,11 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for TestProtocol {
         let my_b = compute_scalar_with_rng("my_b", sample_value, &[]);
         let my_r = compute_scalar_with_rng("my_r", sample_nonce, &[]);
         let my_c = compute_scalar("my_c", commit_to_value, &[("b", (&my_b).into()), ("r", (&my_r).into())]);
-        let c_broadcasted = broadcast(&message_c, &my_c, all_parties);
+        let c_broadcasted = broadcast(&message_c, &my_c);
         let c = receive(&message_c);
-        let all_c = collect(&c, all_parties).with_dependency(&c_broadcasted);
-        let b_broadcasted = broadcast(&message_b, &my_b, all_parties).with_dependency(&all_c);
-        let r_broadcasted = broadcast(&message_r, &my_r, all_parties).with_dependency(&all_c);
+        let all_c = collect(&c, all_parties).with_dependency(&collect(&c_broadcasted, all_parties));
+        let b_broadcasted = broadcast(&message_b, &my_b).with_dependency(&all_c);
+        let r_broadcasted = broadcast(&message_r, &my_r).with_dependency(&all_c);
         let b = receive(&message_b);
         let r = receive(&message_r);
         let hash_correct = compute_mapping_sender_fallible(
@@ -102,9 +102,9 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for TestProtocol {
             &[("c", (&c).into()), ("b", (&b).into()), ("r", (&r).into())],
         );
         let all_hash_correct = collect(&hash_correct, all_parties)
-            .with_dependency(&b_broadcasted)
-            .with_dependency(&r_broadcasted);
-        let all_b = collect(&b, all_parties).with_dependency(&b_broadcasted);
+            .with_dependency(&collect(&b_broadcasted, all_parties))
+            .with_dependency(&collect(&r_broadcasted, all_parties));
+        let all_b = collect(&b, all_parties);
         Ok(compute_scalar("output", gen_output, &[("b", (&all_b).into())]).with_dependency(&all_hash_correct))
     }
 }

--- a/integration-tests/src/distributed_rng.rs
+++ b/integration-tests/src/distributed_rng.rs
@@ -30,7 +30,7 @@ fn commit_to_value<SP: SessionParameters>(args: &Args<SP>) -> Result<u64, Unattr
 fn verify_commitment<SP: SessionParameters>(
     _id: &SP::Verifier,
     args: &Args<SP>,
-) -> Result<(), SenderAttributableError> {
+) -> Result<(), MaybeAttributableError<SenderError>> {
     let b = args.get::<u64>("b")?;
     let r = args.get::<u64>("r")?;
     let c = args.get::<u64>("c")?;

--- a/integration-tests/src/echo_broadcast.rs
+++ b/integration-tests/src/echo_broadcast.rs
@@ -37,16 +37,16 @@ fn verify_echo_pack_correct<SP: SessionParameters>(
     let mut all_ids_except_for_sender = all_ids.clone();
     all_ids_except_for_sender.remove(id);
     if ids_received != all_ids_except_for_sender {
-        return Err(SenderAttributableError::new("Mismatched IDs"));
+        return Err(SenderError::new("Mismatched IDs").into());
     }
 
     // Check that the messages are correctly signed and have correct metadata
     for (from, message) in echoed {
         if from != message.source() {
-            return Err(SenderAttributableError::new("Mismatched source"));
+            return Err(SenderError::new("Mismatched source").into());
         }
         if id != message.metadata().destination() {
-            return Err(SenderAttributableError::new("Mismatched destination"));
+            return Err(SenderError::new("Mismatched destination").into());
         }
 
         let ethalon = received
@@ -54,15 +54,15 @@ fn verify_echo_pack_correct<SP: SessionParameters>(
             .expect("we checked that the ID is present in the message map");
 
         if ethalon.metadata().full_name() != message.metadata().full_name() {
-            return Err(SenderAttributableError::new("Mismatched value name"));
+            return Err(SenderError::new("Mismatched value name").into());
         }
 
         if ethalon.metadata().session_id() != message.metadata().session_id() {
-            return Err(SenderAttributableError::new("Mismatched session ID"));
+            return Err(SenderError::new("Mismatched session ID").into());
         }
 
         if !message.is_signature_correct() {
-            return Err(SenderAttributableError::new("Invalid signature"));
+            return Err(SenderError::new("Invalid signature").into());
         }
     }
 
@@ -95,11 +95,7 @@ fn verify_echo_contents<SP: SessionParameters>(
 
         if !ethalon.payload_hash_matches(message)? {
             let associated_data = ((*ethalon).clone().unverify(), message.clone());
-            return Err(ThirdPartyAttributableError::new(
-                "Mismatched value contents",
-                from,
-                associated_data,
-            ));
+            return Err(ThirdPartyError::new("Mismatched value contents", from, associated_data)?.into());
         }
     }
 

--- a/integration-tests/src/echo_broadcast.rs
+++ b/integration-tests/src/echo_broadcast.rs
@@ -139,7 +139,7 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for EchoBroadcast {
         let (message, all_parties) = build_data;
         let my_value = inputs.get("value")?;
 
-        let value_broadcasted = broadcast(message, my_value, all_parties);
+        let value_broadcasted = broadcast(message, my_value);
         let (values_verified, values) = receive_split(message);
 
         let message_echo = ProtocolMessage::new::<BTreeMap<SP::Verifier, SignedHash<SP>>>("echo");
@@ -154,7 +154,7 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for EchoBroadcast {
         // We don't want to send out values that proved to be incorrect during deserialization checks.
         .with_dependency(&all_values_deserialized);
 
-        let echo_pack_broadcasted = broadcast(&message_echo, &my_echo_pack_sendable, all_parties);
+        let echo_pack_broadcasted = broadcast(&message_echo, &my_echo_pack_sendable);
         let echo_pack = receive(&message_echo);
 
         let all_ids = constant("all_ids", all_parties.ids().cloned().collect::<BTreeSet<_>>());
@@ -167,6 +167,10 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for EchoBroadcast {
                 ("echoed", (&echo_pack).into()),
             ],
         );
+
+        // Note: we are only verifying the echo contents after sending out all the messages.
+        // This may not what one would want to do in a production environment,
+        // but it helps with testing (allows the malicious node to finish successfully).
         let echo_contents_correct = compute_mapping_third_party_fallible(
             "echo_contents_correct",
             verify_echo_contents,
@@ -175,15 +179,15 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for EchoBroadcast {
                 ("echoed", (&echo_pack).into()),
             ],
             verify_echo_contents_error,
-        );
+        )
+        .with_dependency(&collect(&value_broadcasted, all_parties))
+        .with_dependency(&collect(&echo_pack_broadcasted, all_parties));
 
         let all_echo_packs_correct = collect(&echo_packs_correct, all_parties);
         let all_echo_contents_correct = collect(&echo_contents_correct, all_parties);
         let output = mapping_alias("output", &values)
-            .with_dependency(&value_broadcasted)
             .with_dependency(&all_echo_packs_correct)
-            .with_dependency(&all_echo_contents_correct)
-            .with_dependency(&echo_pack_broadcasted);
+            .with_dependency(&all_echo_contents_correct);
 
         Ok(output)
     }

--- a/integration-tests/src/echo_broadcast.rs
+++ b/integration-tests/src/echo_broadcast.rs
@@ -20,7 +20,7 @@ fn prepare_echo_pack<SP: SessionParameters>(
 fn verify_echo_pack_correct<SP: SessionParameters>(
     id: &SP::Verifier,
     args: &Args<SP>,
-) -> Result<(), SenderAttributableError> {
+) -> Result<(), MaybeAttributableError<SenderError>> {
     let all_ids = args.get::<BTreeSet<SP::Verifier>>("all_ids")?;
 
     // The messages we received from all nodes
@@ -72,7 +72,7 @@ fn verify_echo_pack_correct<SP: SessionParameters>(
 fn verify_echo_contents<SP: SessionParameters>(
     id: &SP::Verifier,
     args: &Args<SP>,
-) -> Result<(), ThirdPartyAttributableError<SP>> {
+) -> Result<(), MaybeAttributableError<ThirdPartyError<SP>>> {
     // TODO (#9): since we're sending a message to ourself too, we need to account for that.
     // When short-circuiting is implemented, this function won't be called at all if `id == args.my_id()`.
     if id == args.my_id() {
@@ -274,7 +274,9 @@ mod tests {
 
     use ayatori::{
         dev::{BinaryFormat, Replacement, TestSessionParams, TestSigner, run_sessions_sync},
-        protocol_author_api::{Args, RuntimeError, SerializeArgs, SignedValue, ThirdPartyAttributableError},
+        protocol_author_api::{
+            Args, MaybeAttributableError, RuntimeError, SerializeArgs, SignedValue, ThirdPartyError,
+        },
         protocol_user_api::*,
     };
 
@@ -321,10 +323,10 @@ mod tests {
     }
 
     fn dummy_verification(
-        _orig_value: Result<&(), ThirdPartyAttributableError<SP>>,
+        _orig_value: Result<&(), MaybeAttributableError<ThirdPartyError<SP>>>,
         _id: &<SP as SessionParameters>::Verifier,
         _args: &Args<SP>,
-    ) -> Result<(), ThirdPartyAttributableError<SP>> {
+    ) -> Result<(), MaybeAttributableError<ThirdPartyError<SP>>> {
         Ok(())
     }
 

--- a/integration-tests/src/echo_broadcast.rs
+++ b/integration-tests/src/echo_broadcast.rs
@@ -373,7 +373,10 @@ mod tests {
         assert_eq!(results.reports[&ids[0]].success_ref().unwrap(), &());
         assert!(results.reports[&ids[0]].provable_errors.is_empty());
 
-        assert!(results.reports[&ids[1]].is_unfinishable());
+        assert!(matches!(
+            results.reports[&ids[1]].outcome,
+            SessionOutcome::Unfinishable(..)
+        ));
         assert!(results.reports[&ids[1]].provable_errors.contains_key(&ids[0]));
         assert!(
             results.reports[&ids[1]].provable_errors[&ids[0]]
@@ -381,7 +384,10 @@ mod tests {
                 .is_ok()
         );
 
-        assert!(results.reports[&ids[2]].is_unfinishable());
+        assert!(matches!(
+            results.reports[&ids[2]].outcome,
+            SessionOutcome::Unfinishable(..)
+        ));
         assert!(results.reports[&ids[2]].provable_errors.contains_key(&ids[0]));
         assert!(
             results.reports[&ids[2]].provable_errors[&ids[0]]

--- a/integration-tests/src/evidence_generation.rs
+++ b/integration-tests/src/evidence_generation.rs
@@ -16,7 +16,7 @@ fn verify<SP: SessionParameters>(id: &SP::Verifier, args: &Args<SP>) -> Result<(
     if id == args.my_id() || *x == 1 {
         Ok(())
     } else {
-        Err(SenderAttributableError::new("Invalid x"))
+        Err(SenderError::new("Invalid x").into())
     }
 }
 

--- a/integration-tests/src/evidence_generation.rs
+++ b/integration-tests/src/evidence_generation.rs
@@ -67,10 +67,15 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for TestProtocol {
 
         let all_parties = build_data;
         let my_x = compute_scalar("my_x", gen_value, &[]);
-        let x_broadcasted = broadcast(&message_x, &my_x, all_parties);
+        let x_broadcasted = broadcast(&message_x, &my_x);
         let x = receive(&message_x);
-        let x_correct = compute_mapping_sender_fallible("x_correct", verify, &[("x", (&x).into())]);
-        let all_x_correct = collect(&x_correct, all_parties).with_dependency(&x_broadcasted);
+        // Note that this dependency ensures that the node will send out its messages
+        // before checking correctness of incoming values.
+        // This means that in the test where we make one node send out incorrect values,
+        // it will be able to correctly finish while the others won't.
+        let x_correct = compute_mapping_sender_fallible("x_correct", verify, &[("x", (&x).into())])
+            .with_dependency(&collect(&x_broadcasted, all_parties));
+        let all_x_correct = collect(&x_correct, all_parties);
         let all_x = collect(&x, all_parties);
         Ok(compute_scalar("output", gen_output, &[("x", (&all_x).into())]).with_dependency(&all_x_correct))
     }

--- a/integration-tests/src/evidence_generation.rs
+++ b/integration-tests/src/evidence_generation.rs
@@ -147,7 +147,10 @@ mod tests {
         assert_eq!(results.reports[&ids[0]].success_ref().unwrap(), &4);
         assert!(results.reports[&ids[0]].provable_errors.is_empty());
 
-        assert!(results.reports[&ids[1]].is_unfinishable());
+        assert!(matches!(
+            results.reports[&ids[1]].outcome,
+            SessionOutcome::Unfinishable(..)
+        ));
         assert!(results.reports[&ids[1]].provable_errors.contains_key(&ids[0]));
         assert!(
             results.reports[&ids[1]].provable_errors[&ids[0]]
@@ -155,7 +158,10 @@ mod tests {
                 .is_ok()
         );
 
-        assert!(results.reports[&ids[2]].is_unfinishable());
+        assert!(matches!(
+            results.reports[&ids[2]].outcome,
+            SessionOutcome::Unfinishable(..)
+        ));
         assert!(results.reports[&ids[2]].provable_errors.contains_key(&ids[0]));
         assert!(
             results.reports[&ids[2]].provable_errors[&ids[0]]

--- a/integration-tests/src/evidence_generation.rs
+++ b/integration-tests/src/evidence_generation.rs
@@ -9,7 +9,10 @@ fn gen_value<SP: SessionParameters>(_args: &Args<SP>) -> Result<u64, Unattributa
     Ok(1)
 }
 
-fn verify<SP: SessionParameters>(id: &SP::Verifier, args: &Args<SP>) -> Result<(), SenderAttributableError> {
+fn verify<SP: SessionParameters>(
+    id: &SP::Verifier,
+    args: &Args<SP>,
+) -> Result<(), MaybeAttributableError<SenderError>> {
     let x = args.get::<u64>("x")?;
     // TODO (#9): since we're sending a message to ourself too, we need to account for that.
     // When short-circuiting is implemented, this function won't be called at all if `id == args.my_id()`.

--- a/integration-tests/src/messages.rs
+++ b/integration-tests/src/messages.rs
@@ -98,20 +98,20 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for TestProtocol {
         let all_parties = build_data;
 
         let my_x = compute_scalar("my_x", make_scalar_value, &[]);
-        let x_broadcasted = broadcast(&message_x, &my_x, all_parties);
+        let x_broadcasted = broadcast(&message_x, &my_x);
         let x = receive(&message_x);
-        let all_x = collect(&x, all_parties).with_dependency(&x_broadcasted);
+        let all_x = collect(&x, all_parties).with_dependency(&collect(&x_broadcasted, all_parties));
 
         let my_y = compute_mapping("my_y", make_mapping_elem, &[]);
-        let y_sent = direct_message(&message_y, &my_y, all_parties);
+        let y_sent = direct_message(&message_y, &my_y);
         let y = receive(&message_y);
-        let all_y = collect(&y, all_parties).with_dependency(&y_sent);
+        let all_y = collect(&y, all_parties).with_dependency(&collect(&y_sent, all_parties));
 
         let my_z_group = all_parties.except(party_build_data.id());
         let my_z = compute_mapping("my_z", make_mapping_elem_sans_me, &[]);
-        let z_sent = direct_message(&message_z, &my_z, &my_z_group);
+        let z_sent = direct_message(&message_z, &my_z);
         let z = receive(&message_z);
-        let all_z = collect(&z, &my_z_group).with_dependency(&z_sent);
+        let all_z = collect(&z, &my_z_group).with_dependency(&collect(&z_sent, &my_z_group));
 
         Ok(compute_scalar(
             "output",

--- a/integration-tests/src/nested_protocol.rs
+++ b/integration-tests/src/nested_protocol.rs
@@ -39,9 +39,9 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for Protocol2 {
         let p2 = inputs.get("p2")?;
 
         let my_x = compute_scalar("my_x", make_protocol2_value, &[("p2", p2.into())]);
-        let x_broadcasted = broadcast(&message_x, &my_x, all_parties);
+        let x_broadcasted = broadcast(&message_x, &my_x);
         let x = receive(&message_x);
-        let all_x = collect(&x, all_parties).with_dependency(&x_broadcasted);
+        let all_x = collect(&x, all_parties).with_dependency(&collect(&x_broadcasted, all_parties));
 
         Ok(compute_scalar(
             "output",
@@ -114,9 +114,9 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for Protocol1 {
         let p1 = inputs.get("p1")?;
 
         let my_x = compute_scalar("my_x", make_protocol1_value, &[("p1", p1.into())]);
-        let x_broadcasted = broadcast(&message_x, &my_x, all_parties);
+        let x_broadcasted = broadcast(&message_x, &my_x);
         let x = receive(&message_x);
-        let all_x = collect(&x, all_parties).with_dependency(&x_broadcasted);
+        let all_x = collect(&x, all_parties).with_dependency(&collect(&x_broadcasted, all_parties));
 
         let p1_sum = compute_scalar("p1_sum", make_protocol1_output, &[("x", (&all_x).into())]);
 

--- a/integration-tests/src/secret_reveal.rs
+++ b/integration-tests/src/secret_reveal.rs
@@ -308,7 +308,10 @@ mod tests {
         assert!(results.reports[&ids[0]].success_ref().is_some());
         assert!(results.reports[&ids[0]].provable_errors.is_empty());
 
-        assert!(results.reports[&ids[1]].is_unfinishable());
+        assert!(matches!(
+            results.reports[&ids[1]].outcome,
+            SessionOutcome::Unfinishable(..)
+        ));
         assert!(results.reports[&ids[1]].provable_errors.contains_key(&ids[0]));
         assert!(
             results.reports[&ids[1]].provable_errors[&ids[0]]

--- a/integration-tests/src/secret_reveal.rs
+++ b/integration-tests/src/secret_reveal.rs
@@ -94,12 +94,8 @@ fn verify_secret<SP: SessionParameters>(
     let x_dec = args.get::<u64>("x_dec")?;
     let x_cap = args.get::<u64>("X")?;
     if *x_cap != modpow(GENERATOR, *x_dec) {
-        return Err(SenderAttributableErrorWithReveal::new(
-            "For the decrypted x: g^x != X",
-            *y,
-        ));
+        return Err(SenderErrorWithReveal::new("For the decrypted x: g^x != X", *y)?.into());
     }
-
     Ok(())
 }
 

--- a/integration-tests/src/secret_reveal.rs
+++ b/integration-tests/src/secret_reveal.rs
@@ -175,14 +175,14 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for TestProtocol {
         let my_x_cap = compute_mapping("X", gen_public, &[("x", (&my_x).into())]); // X_i,[]
         let my_y_cap = compute_mapping("Y", gen_dh_public, &[("y", (&my_y).into())]); // Y_i,[]
 
-        let x_cap_sent = direct_message(&message_x, &my_x_cap, all_parties);
-        let y_cap_sent = direct_message(&message_y, &my_y_cap, all_parties);
+        let x_cap_sent = direct_message(&message_x, &my_x_cap);
+        let y_cap_sent = direct_message(&message_y, &my_y_cap);
 
         let x_cap = receive(&message_x); // X_j,[]
         let y_cap = receive(&message_y); // Y_j,[]
 
         let message_y_echo = ProtocolMessage::new::<u64>("Y_echo");
-        let y_echo_sent = direct_message(&message_y_echo, &y_cap, all_parties);
+        let y_echo_sent = direct_message(&message_y_echo, &y_cap);
         let y_echo = receive(&message_y_echo); // Y_i,[]
 
         // for j: C_j,i = x_i,j + Y_j,i^(y_i,j)
@@ -191,7 +191,7 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for TestProtocol {
             encrypt_secret,
             &[("x", (&my_x).into()), ("y", (&my_y).into()), ("Y", (&y_cap).into())],
         );
-        let c_cap_sent = direct_message(&message_c, &my_c_cap, all_parties);
+        let c_cap_sent = direct_message(&message_c, &my_c_cap);
 
         let c_cap = receive(&message_c); // C_i,[]
         let x_decrypted = compute_mapping(
@@ -218,18 +218,18 @@ impl<SP: SessionParameters> ComposableProtocol<SP> for TestProtocol {
                 // But for this test it does not matter.
                 ("Y", (&y_echo).into()), // S_j(Y_i,j) (echoed back to us)
             ],
-        );
+        )
+        .with_dependency(&collect(&x_cap_sent, all_parties))
+        .with_dependency(&collect(&y_cap_sent, all_parties))
+        .with_dependency(&collect(&y_echo_sent, all_parties))
+        .with_dependency(&collect(&c_cap_sent, all_parties));
 
         Ok(compute_scalar(
             "output",
             gen_output,
             &[("x", (&collect(&x_decrypted, all_parties)).into())],
         )
-        .with_dependency(&collect(&x_verified, all_parties))
-        .with_dependency(&x_cap_sent)
-        .with_dependency(&y_cap_sent)
-        .with_dependency(&y_echo_sent)
-        .with_dependency(&c_cap_sent))
+        .with_dependency(&collect(&x_verified, all_parties)))
     }
 }
 

--- a/integration-tests/src/secret_reveal.rs
+++ b/integration-tests/src/secret_reveal.rs
@@ -89,7 +89,7 @@ fn decrypt_secret<SP: SessionParameters>(_id: &SP::Verifier, args: &Args<SP>) ->
 fn verify_secret<SP: SessionParameters>(
     _id: &SP::Verifier,
     args: &Args<SP>,
-) -> Result<(), SenderAttributableErrorWithReveal<SP>> {
+) -> Result<(), MaybeAttributableError<SenderErrorWithReveal<SP>>> {
     let y = args.get::<u64>("y")?;
     let x_dec = args.get::<u64>("x_dec")?;
     let x_cap = args.get::<u64>("X")?;


### PR DESCRIPTION
Fixes #52

Going with our own simple implementation instead of `error-stack`, it's only a few dozen lines anyway, and we want a different approach. Namely:
- Only some errors need tracing (e.g. `RuntimeError`), attributable errors get repackaged into evidences. 
- We only need to remember the string context, not create a whole new type at each trace point.
