### PR TITLE
Flatten logic in `Session`

### DIFF
--- a/ayatori/src/dev/run_sync.rs
+++ b/ayatori/src/dev/run_sync.rs
@@ -101,7 +101,9 @@ impl<SP: SessionParameters> RunSyncConfig<SP> {
                         Task::Deterministic(task) => updates.push(task.execute()),
                         Task::Randomized(task) => updates.push(task.execute(rng)),
                         Task::Send(task) => {
-                            for (destination, message) in task.into_dms()? {
+                            let (update, dms) = task.into_dms()?;
+                            updates.push(update);
+                            for (destination, message) in dms {
                                 let queue = messages.get_mut(&destination).ok_or_else(|| {
                                     RuntimeError::new(format!("{id:?} not found in the map of message queues"))
                                 })?;

--- a/ayatori/src/execution/config.rs
+++ b/ayatori/src/execution/config.rs
@@ -1,6 +1,9 @@
 use alloc::{collections::BTreeSet, vec::Vec};
 
-use super::{session::MessageAttributableError, task::SendTask};
+use super::{
+    session::MessageAttributableError,
+    task::{SendTask, SessionUpdate},
+};
 use crate::{
     entities::{Message, RuntimeError},
     traits::SessionParameters,
@@ -12,7 +15,9 @@ pub trait SessionRunnerConfiguration<SP: SessionParameters>: 'static {
     type MessageOut: 'static + Send + Sync + From<MessageAttributableError<SP>>;
 
     /// Converts [`SendTask`] into outgoing messages.
-    fn send_task_into_messages_out(task: SendTask<SP>) -> Result<impl Iterator<Item = Self::MessageOut>, RuntimeError>;
+    fn send_task_into_messages_out(
+        task: SendTask<SP>,
+    ) -> Result<(SessionUpdate<SP>, impl Iterator<Item = Self::MessageOut>), RuntimeError>;
 
     /// Converts the outgoing messages into direct messages.
     #[expect(clippy::type_complexity)]
@@ -29,11 +34,14 @@ pub struct DirectMessagesOnly;
 impl<SP: SessionParameters> SessionRunnerConfiguration<SP> for DirectMessagesOnly {
     type MessageOut = DMsOnlyMessageOut<SP>;
 
-    fn send_task_into_messages_out(task: SendTask<SP>) -> Result<impl Iterator<Item = Self::MessageOut>, RuntimeError> {
-        Ok(task
-            .into_dms()?
+    fn send_task_into_messages_out(
+        task: SendTask<SP>,
+    ) -> Result<(SessionUpdate<SP>, impl Iterator<Item = Self::MessageOut>), RuntimeError> {
+        let (update, dms) = task.into_dms()?;
+        let iter = dms
             .into_iter()
-            .map(|(destination, message)| DMsOnlyMessageOut::DirectMessage { destination, message }))
+            .map(|(destination, message)| DMsOnlyMessageOut::DirectMessage { destination, message });
+        Ok((update, iter))
     }
 
     #[cfg(feature = "dev")]
@@ -54,15 +62,18 @@ pub struct BroadcastsSupported;
 impl<SP: SessionParameters> SessionRunnerConfiguration<SP> for BroadcastsSupported {
     type MessageOut = BCsSupportedMessageOut<SP>;
 
-    fn send_task_into_messages_out(task: SendTask<SP>) -> Result<impl Iterator<Item = Self::MessageOut>, RuntimeError> {
-        let (bcs, dms) = task.into_bcs_and_dms()?;
-        Ok(bcs
+    fn send_task_into_messages_out(
+        task: SendTask<SP>,
+    ) -> Result<(SessionUpdate<SP>, impl Iterator<Item = Self::MessageOut>), RuntimeError> {
+        let (update, bcs, dms) = task.into_bcs_and_dms()?;
+        let iter = bcs
             .into_iter()
             .map(|(destinations, message)| BCsSupportedMessageOut::BroadcastMessage { destinations, message })
             .chain(
                 dms.into_iter()
                     .map(|(destination, message)| BCsSupportedMessageOut::DirectMessage { destination, message }),
-            ))
+            );
+        Ok((update, iter))
     }
 
     #[cfg(feature = "dev")]

--- a/ayatori/src/execution/evidence.rs
+++ b/ayatori/src/execution/evidence.rs
@@ -221,6 +221,12 @@ impl<SP: SessionParameters, P: ExecutableProtocol<SP>> SenderErrorEvidence<SP, P
     }
 }
 
+impl<SP: SessionParameters, P: ExecutableProtocol<SP>> From<SenderErrorEvidence<SP, P>> for EvidenceKind<SP, P> {
+    fn from(source: SenderErrorEvidence<SP, P>) -> Self {
+        Self::SenderError(source)
+    }
+}
+
 #[derive_where::derive_where(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct SenderErrorWithRevealEvidence<SP: SessionParameters, P: ExecutableProtocol<SP>> {
     reported_by: SP::Verifier,
@@ -267,6 +273,14 @@ impl<SP: SessionParameters, P: ExecutableProtocol<SP>> SenderErrorWithRevealEvid
         .or_with_context(|| "Failed to build the reproduction subtree".into())?;
 
         run_evidence_verification_session(session, &self.reported_by, guilty_party, &self.signed_values)
+    }
+}
+
+impl<SP: SessionParameters, P: ExecutableProtocol<SP>> From<SenderErrorWithRevealEvidence<SP, P>>
+    for EvidenceKind<SP, P>
+{
+    fn from(source: SenderErrorWithRevealEvidence<SP, P>) -> Self {
+        Self::SenderErrorWithReveal(source)
     }
 }
 
@@ -408,5 +422,11 @@ impl<SP: SessionParameters, P: ExecutableProtocol<SP>> ThirdPartyErrorEvidence<S
         verification
             .call(guilty_party, session_id, self.error.associated_data())
             .or_with_context(|| "Failed to run the associated verification function".into())
+    }
+}
+
+impl<SP: SessionParameters, P: ExecutableProtocol<SP>> From<ThirdPartyErrorEvidence<SP, P>> for EvidenceKind<SP, P> {
+    fn from(source: ThirdPartyErrorEvidence<SP, P>) -> Self {
+        Self::ThirdPartyError(source)
     }
 }

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -31,9 +31,9 @@ use super::{
 use crate::dev::Replacement;
 use crate::{
     entities::{
-        AnyTag, Args, AssociatedData, ComputedScalarTag, DeserializeArgs, Erasable, EvidenceVerdict, MappingFunction,
-        MappingTag, Message, MessageId, RemoteSignedTag, RuntimeError, ScalarFunction, ScalarTag, SerializeArgs,
-        SessionId, SignedValue, SpuriousError, Value, VerifiedValue,
+        AnyTag, Args, AssociatedData, ComputedScalarTag, DeserializeArgs, Erasable, EvidenceVerdict, FullName,
+        MappingFunction, MappingTag, Message, MessageId, RemoteSignedTag, RuntimeError, ScalarFunction, ScalarTag,
+        SerializeArgs, SessionId, SignedValue, SpuriousError, Value, VerifiedValue,
     },
     flat_representation::{Action, OnError, Ruleset, RulesetState},
     graph_representation::{AnyNode, ArgNodes, OutputNode, PartyBuildData, PrivateInputs, PublicInputs},
@@ -561,38 +561,8 @@ where
                     Ok(AddSessionUpdate::StateChanged)
                 }
                 OnError::CollectEvidence(message_names) => {
-                    let mut signed_values = Vec::new();
-                    for name in message_names {
-                        let value = self
-                            .storage
-                            .get_elem(
-                                &MappingTag::from(RemoteSignedTag::new_with_full_name(&name)),
-                                &guilty_party,
-                            )
-                            .or_with_context(|| {
-                                format!(
-                                    concat!(
-                                        "Failed to get the signed message `{}` ",
-                                        "to attach to the evidence of `{}` failure"
-                                    ),
-                                    name, store_in
-                                )
-                            })?;
-                        let signed_value = value
-                            .downcast_ref::<VerifiedValue<SP>>()
-                            .or_with_context(|| {
-                                format!(
-                                    concat!(
-                                        "Failed to downcast the signed message `{}` ",
-                                        "to attach to the evidence of `{}` failure"
-                                    ),
-                                    name, store_in
-                                )
-                            })?
-                            .clone()
-                            .unverify();
-                        signed_values.push(signed_value);
-                    }
+                    let signed_values = collect_evidence(&self.storage, &guilty_party, &message_names)
+                        .or_with_context(|| format!("Failed to collect evidence for {store_in} failure"))?;
                     let evidence = EvidenceKind::SenderError(SenderErrorEvidence::new(
                         &self.verifier,
                         &store_in,
@@ -614,38 +584,8 @@ where
                     Ok(AddSessionUpdate::StateChanged)
                 }
                 OnError::CollectEvidence(message_names) => {
-                    let mut signed_values = Vec::new();
-                    for name in message_names {
-                        let value = self
-                            .storage
-                            .get_elem(
-                                &MappingTag::from(RemoteSignedTag::new_with_full_name(&name)),
-                                &guilty_party,
-                            )
-                            .or_with_context(|| {
-                                format!(
-                                    concat!(
-                                        "Failed to get the signed message `{}` ",
-                                        "to attach to the evidence of `{}` failure"
-                                    ),
-                                    name, store_in
-                                )
-                            })?;
-                        let signed_value = value
-                            .downcast_ref::<VerifiedValue<SP>>()
-                            .or_with_context(|| {
-                                format!(
-                                    concat!(
-                                        "Failed to downcast the signed message `{}` ",
-                                        "to attach to the evidence of `{}` failure"
-                                    ),
-                                    name, store_in
-                                )
-                            })?
-                            .clone()
-                            .unverify();
-                        signed_values.push(signed_value);
-                    }
+                    let signed_values = collect_evidence(&self.storage, &guilty_party, &message_names)
+                        .or_with_context(|| format!("Failed to collect evidence for {store_in} failure"))?;
                     let evidence = EvidenceKind::SenderErrorWithReveal(SenderErrorWithRevealEvidence::new(
                         &self.verifier,
                         &store_in,
@@ -722,6 +662,29 @@ where
             }
         }
     }
+}
+
+fn collect_evidence<SP: SessionParameters>(
+    storage: &Storage<SP::Verifier>,
+    guilty_party: &SP::Verifier,
+    message_names: &BTreeSet<FullName>,
+) -> Result<Vec<SignedValue<SP>>, RuntimeError> {
+    let mut signed_values = Vec::new();
+    for name in message_names {
+        let value = storage
+            .get_elem(
+                &MappingTag::from(RemoteSignedTag::new_with_full_name(name)),
+                guilty_party,
+            )
+            .or_with_context(|| format!("Failed to get the signed message `{name}`"))?;
+        let signed_value = value
+            .downcast_ref::<VerifiedValue<SP>>()
+            .or_with_context(|| format!("Failed to downcast the signed message `{name}`"))?
+            .clone()
+            .unverify();
+        signed_values.push(signed_value);
+    }
+    Ok(signed_values)
 }
 
 /// A wrapper for a session that has reached the output.

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -28,7 +28,7 @@ use crate::{
         AnyTag, AssociatedData, ComputedScalarTag, Erasable, EvidenceVerdict, FullName, MappingTag, Message, MessageId,
         RemoteSignedTag, RuntimeError, ScalarTag, SessionId, SignedValue, SpuriousError, Value, VerifiedValue,
     },
-    flat_representation::{Action, OnError, Ruleset, RulesetState},
+    flat_representation::{Action, OnError, Ruleset, RulesetState, RulesetStateChange},
     graph_representation::{AnyNode, ArgNodes, OutputNode, PartyBuildData, PrivateInputs, PublicInputs},
     traced_error::{Traceable, TraceableResult},
     traits::{ExecutableProtocol, SessionParameters},
@@ -220,8 +220,7 @@ where
         self.storage
             .set_scalar(store_in, value)
             .or_with_context(|| format!("Failed to store the scalar result of `{store_in}`"))?;
-        self.ruleset.update_with_scalar_ready(store_in);
-        Ok(AddSessionUpdate::StateChanged)
+        Ok(self.ruleset.update_with_scalar_ready(store_in).into())
     }
 
     fn add_element(
@@ -234,24 +233,22 @@ where
             .set_elem(store_in, id, value)
             .or_with_context(|| format!("Failed to store a mapping element result of `{store_in}`"))?;
         self.ruleset.update_with_element_ready(store_in, id);
-        // The output node is a scalar, adding an element to a mapping node
-        // will not finish the protocol or make it unfinishable.
         Ok(AddSessionUpdate::StateDidNotChange)
     }
 
     #[must_use]
     fn register_provable_error(&mut self, evidence: Evidence<SP, P>) -> AddSessionUpdate<SP> {
-        self.ruleset.update_with_banned_party(evidence.guilty_party());
+        let state_change = self.ruleset.update_with_banned_party(evidence.guilty_party());
         self.provable_errors.insert(evidence.guilty_party().clone(), evidence);
-        AddSessionUpdate::StateChanged
+        state_change.into()
     }
 
     #[must_use]
     fn register_attributable_error(&mut self, guilty_party: SP::Verifier, tag: &MappingTag) -> AddSessionUpdate<SP> {
-        self.ruleset.update_with_banned_party(&guilty_party);
+        let state_change = self.ruleset.update_with_banned_party(&guilty_party);
         self.attributable_errors
             .insert(guilty_party, format!("Error when calculating {tag}"));
-        AddSessionUpdate::StateChanged
+        state_change.into()
     }
 
     fn try_add_verified_value(
@@ -299,9 +296,9 @@ where
 
     #[must_use]
     fn register_banned_party(&mut self, guilty_party: SP::Verifier, reason: String) -> AddSessionUpdate<SP> {
-        self.ruleset.update_with_banned_party(&guilty_party);
+        let state_change = self.ruleset.update_with_banned_party(&guilty_party);
         self.external_bans.insert(guilty_party, reason);
-        AddSessionUpdate::StateChanged
+        state_change.into()
     }
 
     fn make_report(self, outcome: SessionOutcome<SP, P>) -> SessionReport<SP, P> {
@@ -690,6 +687,15 @@ enum AddSessionUpdate<SP: SessionParameters> {
     StateDidNotChange,
     MessageAttributableError(MessageAttributableError<SP>),
     SpuriousError { store_in: AnyTag, error: SpuriousError },
+}
+
+impl<SP: SessionParameters> From<RulesetStateChange> for AddSessionUpdate<SP> {
+    fn from(source: RulesetStateChange) -> Self {
+        match source {
+            RulesetStateChange::Changed => Self::StateChanged,
+            RulesetStateChange::NotChanged => Self::StateDidNotChange,
+        }
+    }
 }
 
 /// Contains the specifics about why the session was impossible to finalize.

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -301,29 +301,15 @@ where
             return Ok(Some(task.into()));
         }
 
-        while let Some(action) = self.ruleset.pop_action() {
-            match action {
-                Action::SendBC(action) => {
-                    return Ok(Some(Task::from_send_bc_action(&self.storage, action)?));
-                }
-                Action::SendDM(action) => {
-                    return Ok(Some(Task::from_send_dm_action(&self.storage, action)?));
-                }
+        if let Some(action) = self.ruleset.pop_action() {
+            return Ok(Some(match action {
+                Action::SendBC(action) => Task::from_send_bc_action(&self.storage, action)?,
+                Action::SendDM(action) => Task::from_send_dm_action(&self.storage, action)?,
                 Action::ComputeScalar(action) => {
-                    return Ok(Some(Task::from_compute_scalar_action(
-                        &self.data.id,
-                        self.verifier(),
-                        &self.storage,
-                        action,
-                    )?));
+                    Task::from_compute_scalar_action(&self.data.id, self.verifier(), &self.storage, action)?
                 }
                 Action::ComputeMappingElement(action) => {
-                    return Ok(Some(Task::from_compute_mapping_element_action(
-                        &self.data.id,
-                        self.verifier(),
-                        &self.storage,
-                        action,
-                    )?));
+                    Task::from_compute_mapping_element_action(&self.data.id, self.verifier(), &self.storage, action)?
                 }
                 Action::ComputeSerializeAndSignScalar(action) => {
                     let signer = self.signer.as_ref().ok_or_else(|| {
@@ -333,12 +319,7 @@ where
                             "Attempted to execute a serialize-and-sign node in a session without a signer",
                         )
                     })?;
-                    return Ok(Some(Task::from_compute_serialize_and_sign_scalar_action(
-                        signer,
-                        &self.data.id,
-                        &self.storage,
-                        action,
-                    )?));
+                    Task::from_compute_serialize_and_sign_scalar_action(signer, &self.data.id, &self.storage, action)?
                 }
                 Action::ComputeSerializeAndSignElement(action) => {
                     let signer = self.signer.as_ref().ok_or_else(|| {
@@ -348,40 +329,14 @@ where
                             "Attempted to execute a serialize-and-sign node in a session without a signer",
                         )
                     })?;
-                    return Ok(Some(Task::from_compute_serialize_and_sign_element_action(
-                        signer,
-                        &self.data.id,
-                        &self.storage,
-                        action,
-                    )?));
+                    Task::from_compute_serialize_and_sign_element_action(signer, &self.data.id, &self.storage, action)?
                 }
                 Action::ComputeDeserializeElement(action) => {
-                    return Ok(Some(Task::from_compute_deserialize_element_action(
-                        &self.storage,
-                        action,
-                    )?));
+                    Task::from_compute_deserialize_element_action(&self.storage, action)?
                 }
-                Action::MergeScalar(action) => {
-                    self.add_scalar(
-                        &ScalarTag::from(action.store_in.clone()),
-                        self.storage
-                            .get_one_or_both_as_value(&action.left, &action.right)
-                            .or_with_context(|| {
-                                format!("Failed to get the argument for `{}` from storage", action.store_in)
-                            })?,
-                    )?;
-                }
-                Action::Collect(action) => {
-                    self.add_scalar(
-                        &action.store_in,
-                        self.storage
-                            .get_mapping_as_value(&action.values, &action.sources)
-                            .or_with_context(|| {
-                                format!("Failed to get the argument for `{}` from storage", action.store_in)
-                            })?,
-                    )?;
-                }
-            }
+                Action::MergeScalar(action) => Task::from_merge_scalars_action(&self.storage, action)?,
+                Action::Collect(action) => Task::from_collect_action(&self.storage, action)?,
+            }));
         }
 
         Ok(None)
@@ -554,6 +509,14 @@ where
             SessionUpdateEnum::ExternalBan { party_id, reason } => {
                 self.register_banned_party(party_id, reason);
                 Ok(AddSessionUpdate::StateChanged)
+            }
+            SessionUpdateEnum::MergedScalars { store_in, result } => {
+                self.add_scalar(&ScalarTag::from(store_in), result)?;
+                Ok(AddSessionUpdate::StateDidNotChange)
+            }
+            SessionUpdateEnum::Collected { store_in, result } => {
+                self.add_scalar(&store_in, result)?;
+                Ok(AddSessionUpdate::StateDidNotChange)
             }
         }
     }

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -19,18 +19,14 @@ use super::{
         ThirdPartyErrorEvidence,
     },
     storage::Storage,
-    task::{
-        DeserializeElementTask, PreprocessMessageTask, SendTask, SerializeAndSignElementTask,
-        SerializeAndSignScalarTask, SessionUpdate, SessionUpdateEnum, Task,
-    },
+    task::{PreprocessMessageTask, SessionUpdate, SessionUpdateEnum, Task},
 };
 #[cfg(feature = "dev")]
 use crate::dev::Replacement;
 use crate::{
     entities::{
-        AnyTag, Args, AssociatedData, ComputedScalarTag, DeserializeArgs, Erasable, EvidenceVerdict, FullName,
-        MappingTag, Message, MessageId, RemoteSignedTag, RuntimeError, ScalarTag, SerializeArgs, SessionId,
-        SignedValue, SpuriousError, Value, VerifiedValue,
+        AnyTag, AssociatedData, ComputedScalarTag, Erasable, EvidenceVerdict, FullName, MappingTag, Message, MessageId,
+        RemoteSignedTag, RuntimeError, ScalarTag, SessionId, SignedValue, SpuriousError, Value, VerifiedValue,
     },
     flat_representation::{Action, OnError, Ruleset, RulesetState},
     graph_representation::{AnyNode, ArgNodes, OutputNode, PartyBuildData, PrivateInputs, PublicInputs},
@@ -308,63 +304,47 @@ where
         while let Some(action) = self.ruleset.pop_action() {
             match action {
                 Action::SendBC(action) => {
-                    let value = self
-                        .storage
-                        .get_scalar(&ScalarTag::from(action.to_send))
-                        .or_with_context(|| {
-                            format!("Failed to get the argument for `{}` from storage", action.store_in)
-                        })?;
-                    let signed_value = value
-                        .downcast::<SignedValue<SP>>()
-                        .or_with_context(|| "Failed to downcast the value to be sent".into())?;
+                    let store_in = ScalarTag::from(action.store_in.clone());
+                    let task = Task::from_send_bc_action(&self.storage, action)?;
+
                     // Note that we record the fact that the message was *sent*, not *delivered*.
                     //
                     // TODO: This is the only place where we use `add_element()` outside of `with_update()`,
                     // and we can get away with it because it does not change the state.
                     // Can we enforce it in types somehow? In general, `add_element()` never changes state.
-                    self.add_scalar(&ScalarTag::from(action.store_in), Value::new(()))?;
-                    return Ok(Some(SendTask::new_broadcast(action.destinations, signed_value).into()));
+                    self.add_scalar(&store_in, Value::new(()))?;
+
+                    return Ok(Some(task));
                 }
                 Action::SendDM(action) => {
-                    let value = self
-                        .storage
-                        .get_elem(&MappingTag::from(action.to_send), &action.destination)
-                        .or_with_context(|| {
-                            format!("Failed to get the argument for `{}` from storage", action.store_in)
-                        })?;
-                    let signed_value = value
-                        .downcast::<SignedValue<SP>>()
-                        .or_with_context(|| "Failed to downcast the value to be sent".into())?;
+                    let store_in = MappingTag::from(action.store_in.clone());
+                    let destination = action.destination.clone();
+                    let task = Task::from_send_dm_action(&self.storage, action)?;
+
                     // Note that we record the fact that the message was *sent*, not *delivered*.
                     //
                     // TODO: This is the only place where we use `add_element()` outside of `with_update()`,
                     // and we can get away with it because it does not change the state.
                     // Can we enforce it in types somehow? In general, `add_element()` never changes state.
-                    self.add_element(&MappingTag::from(action.store_in), &action.destination, Value::new(()))?;
-                    return Ok(Some(SendTask::new_direct(action.destination, signed_value).into()));
+                    self.add_element(&store_in, &destination, Value::new(()))?;
+
+                    return Ok(Some(task));
                 }
                 Action::ComputeScalar(action) => {
-                    let arg_values = self.storage.get_scalar_args(action.args).or_with_context(|| {
-                        format!("Failed to get the arguments for `{}` from storage", action.store_in)
-                    })?;
-                    let args = Args::new(&self.data.id, self.verifier(), arg_values);
-                    return Ok(Some(Task::from_scalar_function(action.store_in, action.function, args)));
+                    return Ok(Some(Task::from_compute_scalar_action(
+                        &self.data.id,
+                        self.verifier(),
+                        &self.storage,
+                        action,
+                    )?));
                 }
                 Action::ComputeMappingElement(action) => {
-                    let arg_values = self
-                        .storage
-                        .get_scalar_or_mapping_args(&action.index, action.args)
-                        .or_with_context(|| {
-                            format!("Failed to get the arguments for `{}` from storage", action.store_in)
-                        })?;
-                    let args = Args::new(&self.data.id, self.verifier(), arg_values);
-                    return Ok(Some(Task::from_mapping_function(
-                        action.store_in,
-                        action.function,
-                        action.index,
-                        args,
-                        action.on_error,
-                    )));
+                    return Ok(Some(Task::from_compute_mapping_element_action(
+                        &self.data.id,
+                        self.verifier(),
+                        &self.storage,
+                        action,
+                    )?));
                 }
                 Action::ComputeSerializeAndSignScalar(action) => {
                     let signer = self.signer.as_ref().ok_or_else(|| {
@@ -374,17 +354,12 @@ where
                             "Attempted to execute a serialize-and-sign node in a session without a signer",
                         )
                     })?;
-
-                    let value = self
-                        .storage
-                        .get_scalar(&action.data)
-                        .or_with_context(|| format!("Failed to get the argument for `{}` from storage", action.data))?;
-
-                    let args =
-                        SerializeArgs::new(signer, &self.data.id, action.message_name, action.serde_adapter, value);
-                    return Ok(Some(
-                        SerializeAndSignScalarTask::new(action.store_in, action.function, args).into(),
-                    ));
+                    return Ok(Some(Task::from_compute_serialize_and_sign_scalar_action(
+                        signer,
+                        &self.data.id,
+                        &self.storage,
+                        action,
+                    )?));
                 }
                 Action::ComputeSerializeAndSignElement(action) => {
                     let signer = self.signer.as_ref().ok_or_else(|| {
@@ -394,37 +369,18 @@ where
                             "Attempted to execute a serialize-and-sign node in a session without a signer",
                         )
                     })?;
-
-                    let value = match action.data {
-                        AnyTag::Scalar(tag) => self.storage.get_scalar(&tag),
-                        AnyTag::Mapping(tag) => self.storage.get_elem(&tag, &action.index),
-                    }
-                    .or_with_context(|| format!("Failed to get the argument for `{}` from storage", action.store_in))?;
-
-                    let args =
-                        SerializeArgs::new(signer, &self.data.id, action.message_name, action.serde_adapter, value);
-                    return Ok(Some(
-                        SerializeAndSignElementTask::new(action.store_in, action.function, action.index, args).into(),
-                    ));
+                    return Ok(Some(Task::from_compute_serialize_and_sign_element_action(
+                        signer,
+                        &self.data.id,
+                        &self.storage,
+                        action,
+                    )?));
                 }
                 Action::ComputeDeserializeElement(action) => {
-                    let value = self
-                        .storage
-                        .get_elem(&MappingTag::from(action.data), &action.index)
-                        .or_with_context(|| {
-                            format!("Failed to get the argument for `{}` from storage", action.store_in)
-                        })?;
-                    let args = DeserializeArgs::new(&action.expected_senders, action.serde_adapter, value);
-                    return Ok(Some(
-                        DeserializeElementTask::new(
-                            action.store_in,
-                            action.function,
-                            action.index,
-                            args,
-                            action.on_error,
-                        )
-                        .into(),
-                    ));
+                    return Ok(Some(Task::from_compute_deserialize_element_action(
+                        &self.storage,
+                        action,
+                    )?));
                 }
                 Action::MergeScalar(action) => {
                     self.add_scalar(

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -20,10 +20,7 @@ use super::{
     },
     storage::Storage,
     task::{
-        DeserializeElementTask, ElementSenderAttributableTask, ElementSenderAttributableWithRevealTask,
-        ElementThirdPartyAttributableTask, ElementUnattributableTask, PreprocessMessageTask,
-        RngElementUnattributableTask, RngScalarUnattributableTask, ScalarThirdPartyAttributableTask,
-        ScalarUnattributableOptionalTask, ScalarUnattributableTask, SendTask, SerializeAndSignElementTask,
+        DeserializeElementTask, PreprocessMessageTask, SendTask, SerializeAndSignElementTask,
         SerializeAndSignScalarTask, SessionUpdate, SessionUpdateEnum, Task,
     },
 };
@@ -32,8 +29,8 @@ use crate::dev::Replacement;
 use crate::{
     entities::{
         AnyTag, Args, AssociatedData, ComputedScalarTag, DeserializeArgs, Erasable, EvidenceVerdict, FullName,
-        MappingFunction, MappingTag, Message, MessageId, RemoteSignedTag, RuntimeError, ScalarFunction, ScalarTag,
-        SerializeArgs, SessionId, SignedValue, SpuriousError, Value, VerifiedValue,
+        MappingTag, Message, MessageId, RemoteSignedTag, RuntimeError, ScalarTag, SerializeArgs, SessionId,
+        SignedValue, SpuriousError, Value, VerifiedValue,
     },
     flat_representation::{Action, OnError, Ruleset, RulesetState},
     graph_representation::{AnyNode, ArgNodes, OutputNode, PartyBuildData, PrivateInputs, PublicInputs},
@@ -360,20 +357,7 @@ where
                         .get_scalar_args(args)
                         .or_with_context(|| format!("Failed to get the arguments for `{store_in}` from storage"))?;
                     let args = Args::new(&self.data.id, self.verifier(), arg_values);
-                    return Ok(Some(match function {
-                        ScalarFunction::Unattributable(function) => {
-                            ScalarUnattributableTask::new(store_in, function, args).into()
-                        }
-                        ScalarFunction::UnattributableOptional(function) => {
-                            ScalarUnattributableOptionalTask::new(store_in, function, args).into()
-                        }
-                        ScalarFunction::UnattributableWithRng(function) => {
-                            RngScalarUnattributableTask::new(store_in, function, args).into()
-                        }
-                        ScalarFunction::ThirdPartyAttributable(function) => {
-                            ScalarThirdPartyAttributableTask::new(store_in, function, args).into()
-                        }
-                    }));
+                    return Ok(Some(Task::from_scalar_function(store_in, function, args)));
                 }
                 Action::ComputeMappingElement {
                     store_in,
@@ -387,24 +371,9 @@ where
                         .get_scalar_or_mapping_args(&index, args)
                         .or_with_context(|| format!("Failed to get the arguments for `{store_in}` from storage"))?;
                     let args = Args::new(&self.data.id, self.verifier(), arg_values);
-                    return Ok(Some(match function {
-                        MappingFunction::Unattributable(function) => {
-                            ElementUnattributableTask::new(store_in, function, index, args).into()
-                        }
-                        MappingFunction::UnattributableWithRng(function) => {
-                            RngElementUnattributableTask::new(store_in, function, index, args).into()
-                        }
-                        MappingFunction::SenderAttributable(function) => {
-                            ElementSenderAttributableTask::new(store_in, function, index, args, on_error).into()
-                        }
-                        MappingFunction::SenderAttributableWithReveal(function) => {
-                            ElementSenderAttributableWithRevealTask::new(store_in, function, index, args, on_error)
-                                .into()
-                        }
-                        MappingFunction::ThirdPartyAttributable(function) => {
-                            ElementThirdPartyAttributableTask::new(store_in, function, index, args).into()
-                        }
-                    }));
+                    return Ok(Some(Task::from_mapping_function(
+                        store_in, function, index, args, on_error,
+                    )));
                 }
                 Action::ComputeSerializeAndSignScalar {
                     store_in,

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -304,31 +304,10 @@ where
         while let Some(action) = self.ruleset.pop_action() {
             match action {
                 Action::SendBC(action) => {
-                    let store_in = ScalarTag::from(action.store_in.clone());
-                    let task = Task::from_send_bc_action(&self.storage, action)?;
-
-                    // Note that we record the fact that the message was *sent*, not *delivered*.
-                    //
-                    // TODO: This is the only place where we use `add_element()` outside of `with_update()`,
-                    // and we can get away with it because it does not change the state.
-                    // Can we enforce it in types somehow? In general, `add_element()` never changes state.
-                    self.add_scalar(&store_in, Value::new(()))?;
-
-                    return Ok(Some(task));
+                    return Ok(Some(Task::from_send_bc_action(&self.storage, action)?));
                 }
                 Action::SendDM(action) => {
-                    let store_in = MappingTag::from(action.store_in.clone());
-                    let destination = action.destination.clone();
-                    let task = Task::from_send_dm_action(&self.storage, action)?;
-
-                    // Note that we record the fact that the message was *sent*, not *delivered*.
-                    //
-                    // TODO: This is the only place where we use `add_element()` outside of `with_update()`,
-                    // and we can get away with it because it does not change the state.
-                    // Can we enforce it in types somehow? In general, `add_element()` never changes state.
-                    self.add_element(&store_in, &destination, Value::new(()))?;
-
-                    return Ok(Some(task));
+                    return Ok(Some(Task::from_send_dm_action(&self.storage, action)?));
                 }
                 Action::ComputeScalar(action) => {
                     return Ok(Some(Task::from_compute_scalar_action(
@@ -438,6 +417,14 @@ where
     fn with_update_inner(&mut self, result: SessionUpdate<SP>) -> Result<AddSessionUpdate<SP>, RuntimeError> {
         match result.into_inner() {
             SessionUpdateEnum::NoActionNeeded => Ok(AddSessionUpdate::StateDidNotChange),
+            SessionUpdateEnum::SentBC { store_in } => {
+                self.add_scalar(&ScalarTag::from(store_in), Value::new(()))?;
+                Ok(AddSessionUpdate::StateDidNotChange)
+            }
+            SessionUpdateEnum::SentDM { store_in, destination } => {
+                self.add_element(&MappingTag::from(store_in), &destination, Value::new(()))?;
+                Ok(AddSessionUpdate::StateDidNotChange)
+            }
             SessionUpdateEnum::Received { id, message } => {
                 self.add_message(&id, message);
                 Ok(AddSessionUpdate::StateDidNotChange)

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -216,36 +216,92 @@ where
         &self.verifier
     }
 
-    fn add_scalar(&mut self, store_in: &ScalarTag, value: Value) -> Result<(), RuntimeError> {
+    fn add_scalar(&mut self, store_in: &ScalarTag, value: Value) -> Result<AddSessionUpdate<SP>, RuntimeError> {
         self.storage
             .set_scalar(store_in, value)
             .or_with_context(|| format!("Failed to store the scalar result of `{store_in}`"))?;
         self.ruleset.update_with_scalar_ready(store_in);
-        Ok(())
+        Ok(AddSessionUpdate::StateChanged)
     }
 
-    fn add_element(&mut self, store_in: &MappingTag, id: &SP::Verifier, value: Value) -> Result<(), RuntimeError> {
+    fn add_element(
+        &mut self,
+        store_in: &MappingTag,
+        id: &SP::Verifier,
+        value: Value,
+    ) -> Result<AddSessionUpdate<SP>, RuntimeError> {
         self.storage
             .set_elem(store_in, id, value)
             .or_with_context(|| format!("Failed to store a mapping element result of `{store_in}`"))?;
         self.ruleset.update_with_element_ready(store_in, id);
-        Ok(())
+        // The output node is a scalar, adding an element to a mapping node
+        // will not finish the protocol or make it unfinishable.
+        Ok(AddSessionUpdate::StateDidNotChange)
     }
 
-    fn register_provable_error(&mut self, evidence: Evidence<SP, P>) {
+    #[must_use]
+    fn register_provable_error(&mut self, evidence: Evidence<SP, P>) -> AddSessionUpdate<SP> {
         self.ruleset.update_with_banned_party(evidence.guilty_party());
         self.provable_errors.insert(evidence.guilty_party().clone(), evidence);
+        AddSessionUpdate::StateChanged
     }
 
-    fn register_attributable_error(&mut self, guilty_party: SP::Verifier, tag: &MappingTag) {
+    #[must_use]
+    fn register_attributable_error(&mut self, guilty_party: SP::Verifier, tag: &MappingTag) -> AddSessionUpdate<SP> {
         self.ruleset.update_with_banned_party(&guilty_party);
         self.attributable_errors
             .insert(guilty_party, format!("Error when calculating {tag}"));
+        AddSessionUpdate::StateChanged
     }
 
-    fn register_banned_party(&mut self, guilty_party: SP::Verifier, reason: String) {
+    fn try_add_verified_value(
+        &mut self,
+        store_in: &MappingTag,
+        id: &SP::Verifier,
+        value: Value,
+    ) -> Result<AddSessionUpdate<SP>, RuntimeError> {
+        if let Ok(existing_value) = self.storage.get_elem(store_in, id) {
+            let typed_existing_value = existing_value
+                .downcast_ref::<VerifiedValue<SP>>()
+                .or_with_context(|| format!("Failed to downcast a stored signed message `{store_in}`"))?;
+            let typed_received_value = value
+                .downcast_ref::<VerifiedValue<SP>>()
+                .or_with_context(|| format!("Failed to downcast a newly received message `{store_in}`"))?;
+
+            // Both values are signed, contain the same named value, but are different.
+            // This is a provable failure.
+            // Note that the payload or metadata of either value may still be invalid
+            // (it is possible that it has not been checked yet at this point),
+            // but it does not matter since we already got our evidence.
+            if typed_existing_value.metadata() != typed_received_value.metadata()
+                || typed_existing_value.serialized_value() != typed_received_value.serialized_value()
+            {
+                let evidence = EvidenceKind::ConflictingMessages(ConflictingMessagesEvidence::new(
+                    typed_existing_value,
+                    typed_received_value,
+                ));
+                return Ok(self.register_provable_error(Evidence::new(&self.data.id, id, evidence)));
+            }
+
+            // The message is a duplicate, we cannot do anything at this point.
+            // If the payload/metadata are invalid, the later checks will produce verifiable evidence.
+            // For now we can only report both message IDs that delivered these values,
+            // and let the user deal with it, if possible.
+            let error = MessageAttributableError::DuplicateMessages(DuplicateMessagesError {
+                first: typed_existing_value.message_id().clone(),
+                second: typed_existing_value.message_id().clone(),
+            });
+            return Ok(AddSessionUpdate::MessageAttributableError(error));
+        }
+
+        self.add_element(store_in, id, value)
+    }
+
+    #[must_use]
+    fn register_banned_party(&mut self, guilty_party: SP::Verifier, reason: String) -> AddSessionUpdate<SP> {
         self.ruleset.update_with_banned_party(&guilty_party);
         self.external_bans.insert(guilty_party, reason);
+        AddSessionUpdate::StateChanged
     }
 
     fn make_report(self, outcome: SessionOutcome<SP, P>) -> SessionReport<SP, P> {
@@ -284,13 +340,15 @@ where
     }
 
     /// Registers a received message.
-    fn add_message(&mut self, message_id: &MessageId<SP>, message: Message<SP>) {
+    #[must_use]
+    fn add_message(&mut self, message_id: &MessageId<SP>, message: Message<SP>) -> AddSessionUpdate<SP> {
         let tasks = message
             .into_values()
             .into_iter()
             .map(|signed_value| PreprocessMessageTask::new(&self.data, message_id.clone(), signed_value))
             .collect::<Vec<_>>();
         self.preprocessing_tasks.extend(tasks);
+        AddSessionUpdate::StateDidNotChange
     }
 
     /// Attempts to make a task to execute.
@@ -372,55 +430,34 @@ where
     fn with_update_inner(&mut self, result: SessionUpdate<SP>) -> Result<AddSessionUpdate<SP>, RuntimeError> {
         match result.into_inner() {
             SessionUpdateEnum::NoActionNeeded => Ok(AddSessionUpdate::StateDidNotChange),
-            SessionUpdateEnum::SentBC { store_in } => {
-                self.add_scalar(&ScalarTag::from(store_in), Value::new(()))?;
-                Ok(AddSessionUpdate::StateDidNotChange)
-            }
+            SessionUpdateEnum::SentBC { store_in } => self.add_scalar(&ScalarTag::from(store_in), Value::new(())),
             SessionUpdateEnum::SentDM { store_in, destination } => {
-                self.add_element(&MappingTag::from(store_in), &destination, Value::new(()))?;
-                Ok(AddSessionUpdate::StateDidNotChange)
+                self.add_element(&MappingTag::from(store_in), &destination, Value::new(()))
             }
-            SessionUpdateEnum::Received { id, message } => {
-                self.add_message(&id, message);
-                Ok(AddSessionUpdate::StateDidNotChange)
-            }
+            SessionUpdateEnum::Received { id, message } => Ok(self.add_message(&id, message)),
             SessionUpdateEnum::RuntimeError(error) => Err(error.with_context("Task returned a runtime error")),
             SessionUpdateEnum::SpuriousError { store_in, error } => {
                 Ok(AddSessionUpdate::SpuriousError { store_in, error })
             }
-            SessionUpdateEnum::ComputedScalar { store_in, result } => {
-                self.add_scalar(&store_in, result)?;
-                Ok(AddSessionUpdate::StateChanged)
-            }
+            SessionUpdateEnum::ComputedScalar { store_in, result }
+            | SessionUpdateEnum::Collected { store_in, result } => self.add_scalar(&store_in, result),
             SessionUpdateEnum::ComputedMappingElement {
                 store_in,
                 index,
                 result,
-            } => {
-                self.add_element(&store_in, &index, result)?;
-                Ok(AddSessionUpdate::StateChanged)
-            }
+            } => self.add_element(&store_in, &index, result),
             SessionUpdateEnum::SenderError {
                 store_in,
                 guilty_party,
                 error,
                 on_error,
             } => match on_error {
-                OnError::Escalate => {
-                    self.register_attributable_error(guilty_party, &store_in);
-                    Ok(AddSessionUpdate::StateChanged)
-                }
+                OnError::Escalate => Ok(self.register_attributable_error(guilty_party, &store_in)),
                 OnError::CollectEvidence(message_names) => {
                     let signed_values = collect_evidence(&self.storage, &guilty_party, &message_names)
                         .or_with_context(|| format!("Failed to collect evidence for {store_in} failure"))?;
-                    let evidence = EvidenceKind::SenderError(SenderErrorEvidence::new(
-                        &self.verifier,
-                        &store_in,
-                        signed_values,
-                        error,
-                    ));
-                    self.register_provable_error(Evidence::new(&self.data.id, &guilty_party, evidence));
-                    Ok(AddSessionUpdate::StateChanged)
+                    let evidence = SenderErrorEvidence::new(&self.verifier, &store_in, signed_values, error);
+                    Ok(self.register_provable_error(Evidence::new(&self.data.id, &guilty_party, evidence.into())))
                 }
             },
             SessionUpdateEnum::SenderErrorWithReveal {
@@ -429,73 +466,24 @@ where
                 error,
                 on_error,
             } => match on_error {
-                OnError::Escalate => {
-                    self.register_attributable_error(guilty_party, &store_in);
-                    Ok(AddSessionUpdate::StateChanged)
-                }
+                OnError::Escalate => Ok(self.register_attributable_error(guilty_party, &store_in)),
                 OnError::CollectEvidence(message_names) => {
                     let signed_values = collect_evidence(&self.storage, &guilty_party, &message_names)
                         .or_with_context(|| format!("Failed to collect evidence for {store_in} failure"))?;
-                    let evidence = EvidenceKind::SenderErrorWithReveal(SenderErrorWithRevealEvidence::new(
-                        &self.verifier,
-                        &store_in,
-                        signed_values,
-                        error,
-                    ));
-                    self.register_provable_error(Evidence::new(&self.data.id, &guilty_party, evidence));
-                    Ok(AddSessionUpdate::StateChanged)
+                    let evidence = SenderErrorWithRevealEvidence::new(&self.verifier, &store_in, signed_values, error);
+                    Ok(self.register_provable_error(Evidence::new(&self.data.id, &guilty_party, evidence.into())))
                 }
             },
             SessionUpdateEnum::ThirdPartyError { store_in, error } => {
                 let (guilty_party, error) = error.unpack();
-                let evidence =
-                    EvidenceKind::ThirdPartyError(ThirdPartyErrorEvidence::new(&self.verifier, &store_in, error));
-                self.register_provable_error(Evidence::new(&self.data.id, &guilty_party, evidence));
-                Ok(AddSessionUpdate::StateChanged)
+                let evidence = ThirdPartyErrorEvidence::new(&self.verifier, &store_in, error);
+                Ok(self.register_provable_error(Evidence::new(&self.data.id, &guilty_party, evidence.into())))
             }
             SessionUpdateEnum::Preprocessed {
                 store_in,
                 source,
                 value,
-            } => {
-                if let Ok(existing_value) = self.storage.get_elem(&store_in, &source) {
-                    let typed_existing_value = existing_value
-                        .downcast_ref::<VerifiedValue<SP>>()
-                        .or_with_context(|| format!("Failed to downcast a stored signed message `{store_in}`"))?;
-                    let typed_received_value = value
-                        .downcast_ref::<VerifiedValue<SP>>()
-                        .or_with_context(|| format!("Failed to downcast a newly received message `{store_in}`"))?;
-
-                    // Both values are signed, contain the same named value, but are different.
-                    // This is a provable failure.
-                    // Note that the payload or metadata of either value may still be invalid
-                    // (it is possible that it has not been checked yet at this point),
-                    // but it does not matter since we already got our evidence.
-                    if typed_existing_value.metadata() != typed_received_value.metadata()
-                        || typed_existing_value.serialized_value() != typed_received_value.serialized_value()
-                    {
-                        let evidence = EvidenceKind::ConflictingMessages(ConflictingMessagesEvidence::new(
-                            typed_existing_value,
-                            typed_received_value,
-                        ));
-                        self.register_provable_error(Evidence::new(&self.data.id, &source, evidence));
-                        return Ok(AddSessionUpdate::StateChanged);
-                    }
-
-                    // The message is a duplicate, we cannot do anything at this point.
-                    // If the payload/metadata are invalid, the later checks will produce verifiable evidence.
-                    // For now we can only report both message IDs that delivered these values,
-                    // and let the user deal with it, if possible.
-                    let error = MessageAttributableError::DuplicateMessages(DuplicateMessagesError {
-                        first: typed_existing_value.message_id().clone(),
-                        second: typed_existing_value.message_id().clone(),
-                    });
-                    return Ok(AddSessionUpdate::MessageAttributableError(error));
-                }
-
-                self.add_element(&store_in, &source, value)?;
-                Ok(AddSessionUpdate::StateChanged)
-            }
+            } => self.try_add_verified_value(&store_in, &source, value),
             SessionUpdateEnum::MessageError {
                 message_id,
                 description,
@@ -506,17 +494,9 @@ where
                 });
                 Ok(AddSessionUpdate::MessageAttributableError(error))
             }
-            SessionUpdateEnum::ExternalBan { party_id, reason } => {
-                self.register_banned_party(party_id, reason);
-                Ok(AddSessionUpdate::StateChanged)
-            }
+            SessionUpdateEnum::ExternalBan { party_id, reason } => Ok(self.register_banned_party(party_id, reason)),
             SessionUpdateEnum::MergedScalars { store_in, result } => {
-                self.add_scalar(&ScalarTag::from(store_in), result)?;
-                Ok(AddSessionUpdate::StateDidNotChange)
-            }
-            SessionUpdateEnum::Collected { store_in, result } => {
-                self.add_scalar(&store_in, result)?;
-                Ok(AddSessionUpdate::StateDidNotChange)
+                self.add_scalar(&ScalarTag::from(store_in), result)
             }
         }
     }

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -307,15 +307,13 @@ where
 
         while let Some(action) = self.ruleset.pop_action() {
             match action {
-                Action::SendBC {
-                    store_in,
-                    to_send,
-                    destinations,
-                } => {
+                Action::SendBC(action) => {
                     let value = self
                         .storage
-                        .get_scalar(&ScalarTag::from(to_send))
-                        .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?;
+                        .get_scalar(&ScalarTag::from(action.to_send))
+                        .or_with_context(|| {
+                            format!("Failed to get the argument for `{}` from storage", action.store_in)
+                        })?;
                     let signed_value = value
                         .downcast::<SignedValue<SP>>()
                         .or_with_context(|| "Failed to downcast the value to be sent".into())?;
@@ -324,18 +322,16 @@ where
                     // TODO: This is the only place where we use `add_element()` outside of `with_update()`,
                     // and we can get away with it because it does not change the state.
                     // Can we enforce it in types somehow? In general, `add_element()` never changes state.
-                    self.add_scalar(&ScalarTag::from(store_in), Value::new(()))?;
-                    return Ok(Some(SendTask::new_broadcast(destinations, signed_value).into()));
+                    self.add_scalar(&ScalarTag::from(action.store_in), Value::new(()))?;
+                    return Ok(Some(SendTask::new_broadcast(action.destinations, signed_value).into()));
                 }
-                Action::SendDM {
-                    store_in,
-                    to_send,
-                    destination,
-                } => {
+                Action::SendDM(action) => {
                     let value = self
                         .storage
-                        .get_elem(&MappingTag::from(to_send), &destination)
-                        .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?;
+                        .get_elem(&MappingTag::from(action.to_send), &action.destination)
+                        .or_with_context(|| {
+                            format!("Failed to get the argument for `{}` from storage", action.store_in)
+                        })?;
                     let signed_value = value
                         .downcast::<SignedValue<SP>>()
                         .or_with_context(|| "Failed to downcast the value to be sent".into())?;
@@ -344,44 +340,33 @@ where
                     // TODO: This is the only place where we use `add_element()` outside of `with_update()`,
                     // and we can get away with it because it does not change the state.
                     // Can we enforce it in types somehow? In general, `add_element()` never changes state.
-                    self.add_element(&MappingTag::from(store_in), &destination, Value::new(()))?;
-                    return Ok(Some(SendTask::new_direct(destination, signed_value).into()));
+                    self.add_element(&MappingTag::from(action.store_in), &action.destination, Value::new(()))?;
+                    return Ok(Some(SendTask::new_direct(action.destination, signed_value).into()));
                 }
-                Action::ComputeScalar {
-                    store_in,
-                    function,
-                    args,
-                } => {
-                    let arg_values = self
-                        .storage
-                        .get_scalar_args(args)
-                        .or_with_context(|| format!("Failed to get the arguments for `{store_in}` from storage"))?;
+                Action::ComputeScalar(action) => {
+                    let arg_values = self.storage.get_scalar_args(action.args).or_with_context(|| {
+                        format!("Failed to get the arguments for `{}` from storage", action.store_in)
+                    })?;
                     let args = Args::new(&self.data.id, self.verifier(), arg_values);
-                    return Ok(Some(Task::from_scalar_function(store_in, function, args)));
+                    return Ok(Some(Task::from_scalar_function(action.store_in, action.function, args)));
                 }
-                Action::ComputeMappingElement {
-                    store_in,
-                    function,
-                    index,
-                    args,
-                    on_error,
-                } => {
+                Action::ComputeMappingElement(action) => {
                     let arg_values = self
                         .storage
-                        .get_scalar_or_mapping_args(&index, args)
-                        .or_with_context(|| format!("Failed to get the arguments for `{store_in}` from storage"))?;
+                        .get_scalar_or_mapping_args(&action.index, action.args)
+                        .or_with_context(|| {
+                            format!("Failed to get the arguments for `{}` from storage", action.store_in)
+                        })?;
                     let args = Args::new(&self.data.id, self.verifier(), arg_values);
                     return Ok(Some(Task::from_mapping_function(
-                        store_in, function, index, args, on_error,
+                        action.store_in,
+                        action.function,
+                        action.index,
+                        args,
+                        action.on_error,
                     )));
                 }
-                Action::ComputeSerializeAndSignScalar {
-                    store_in,
-                    function,
-                    data,
-                    message_name,
-                    serde_adapter,
-                } => {
+                Action::ComputeSerializeAndSignScalar(action) => {
                     let signer = self.signer.as_ref().ok_or_else(|| {
                         // This can happen if a serialization node somehow remains
                         // in an evidence verification subtree.
@@ -392,20 +377,16 @@ where
 
                     let value = self
                         .storage
-                        .get_scalar(&data)
-                        .or_with_context(|| format!("Failed to get the argument for `{data}` from storage"))?;
+                        .get_scalar(&action.data)
+                        .or_with_context(|| format!("Failed to get the argument for `{}` from storage", action.data))?;
 
-                    let args = SerializeArgs::new(signer, &self.data.id, message_name, serde_adapter, value);
-                    return Ok(Some(SerializeAndSignScalarTask::new(store_in, function, args).into()));
+                    let args =
+                        SerializeArgs::new(signer, &self.data.id, action.message_name, action.serde_adapter, value);
+                    return Ok(Some(
+                        SerializeAndSignScalarTask::new(action.store_in, action.function, args).into(),
+                    ));
                 }
-                Action::ComputeSerializeAndSignElement {
-                    store_in,
-                    function,
-                    index,
-                    data,
-                    message_name,
-                    serde_adapter,
-                } => {
+                Action::ComputeSerializeAndSignElement(action) => {
                     let signer = self.signer.as_ref().ok_or_else(|| {
                         // This can happen if a serialization node somehow remains
                         // in an evidence verification subtree.
@@ -414,53 +395,55 @@ where
                         )
                     })?;
 
-                    let value = match data {
+                    let value = match action.data {
                         AnyTag::Scalar(tag) => self.storage.get_scalar(&tag),
-                        AnyTag::Mapping(tag) => self.storage.get_elem(&tag, &index),
+                        AnyTag::Mapping(tag) => self.storage.get_elem(&tag, &action.index),
                     }
-                    .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?;
+                    .or_with_context(|| format!("Failed to get the argument for `{}` from storage", action.store_in))?;
 
-                    let args = SerializeArgs::new(signer, &self.data.id, message_name, serde_adapter, value);
+                    let args =
+                        SerializeArgs::new(signer, &self.data.id, action.message_name, action.serde_adapter, value);
                     return Ok(Some(
-                        SerializeAndSignElementTask::new(store_in, function, index, args).into(),
+                        SerializeAndSignElementTask::new(action.store_in, action.function, action.index, args).into(),
                     ));
                 }
-                Action::ComputeDeserializeElement {
-                    store_in,
-                    function,
-                    index,
-                    data,
-                    serde_adapter,
-                    expected_senders,
-                    on_error,
-                } => {
+                Action::ComputeDeserializeElement(action) => {
                     let value = self
                         .storage
-                        .get_elem(&MappingTag::from(data), &index)
-                        .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?;
-                    let args = DeserializeArgs::new(&expected_senders, serde_adapter, value);
+                        .get_elem(&MappingTag::from(action.data), &action.index)
+                        .or_with_context(|| {
+                            format!("Failed to get the argument for `{}` from storage", action.store_in)
+                        })?;
+                    let args = DeserializeArgs::new(&action.expected_senders, action.serde_adapter, value);
                     return Ok(Some(
-                        DeserializeElementTask::new(store_in, function, index, args, on_error).into(),
+                        DeserializeElementTask::new(
+                            action.store_in,
+                            action.function,
+                            action.index,
+                            args,
+                            action.on_error,
+                        )
+                        .into(),
                     ));
                 }
-                Action::MergeScalar { store_in, left, right } => {
+                Action::MergeScalar(action) => {
                     self.add_scalar(
-                        &ScalarTag::from(store_in.clone()),
+                        &ScalarTag::from(action.store_in.clone()),
                         self.storage
-                            .get_one_or_both_as_value(&left, &right)
-                            .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?,
+                            .get_one_or_both_as_value(&action.left, &action.right)
+                            .or_with_context(|| {
+                                format!("Failed to get the argument for `{}` from storage", action.store_in)
+                            })?,
                     )?;
                 }
-                Action::Collect {
-                    store_in,
-                    values,
-                    sources,
-                } => {
+                Action::Collect(action) => {
                     self.add_scalar(
-                        &store_in,
+                        &action.store_in,
                         self.storage
-                            .get_mapping_as_value(&values, &sources)
-                            .or_with_context(|| format!("Failed to get the argument for `{store_in}` from storage"))?,
+                            .get_mapping_as_value(&action.values, &action.sources)
+                            .or_with_context(|| {
+                                format!("Failed to get the argument for `{}` from storage", action.store_in)
+                            })?,
                     )?;
                 }
             }

--- a/ayatori/src/execution/session.rs
+++ b/ayatori/src/execution/session.rs
@@ -28,7 +28,7 @@ use crate::{
         AnyTag, AssociatedData, ComputedScalarTag, Erasable, EvidenceVerdict, FullName, MappingTag, Message, MessageId,
         RemoteSignedTag, RuntimeError, ScalarTag, SessionId, SignedValue, SpuriousError, Value, VerifiedValue,
     },
-    flat_representation::{Action, OnError, Ruleset, RulesetState, RulesetStateChange},
+    flat_representation::{Action, OnError, Ruleset, RulesetStateChange},
     graph_representation::{AnyNode, ArgNodes, OutputNode, PartyBuildData, PrivateInputs, PublicInputs},
     traced_error::{Traceable, TraceableResult},
     traits::{ExecutableProtocol, SessionParameters},
@@ -401,16 +401,10 @@ where
     pub fn with_update(mut self, result: SessionUpdate<SP>) -> Result<SessionState<SP, P>, RuntimeError> {
         let new_state = self.with_update_inner(result)?;
         Ok(match new_state {
-            AddSessionUpdate::StateChanged => {
-                let state = self.ruleset.state().clone();
-                match state {
-                    RulesetState::InProgress => SessionState::InProgress(self),
-                    RulesetState::ReachedOutput => SessionState::ReachedOutput(ReachedOutputSession(self)),
-                    RulesetState::ImpossibleToCollect(tags) => {
-                        let report = self.make_report(SessionOutcome::Unfinishable(UnfinishableOutcome(tags)));
-                        SessionState::Unfinishable(report)
-                    }
-                }
+            AddSessionUpdate::ReachedOutput => SessionState::ReachedOutput(ReachedOutputSession(self)),
+            AddSessionUpdate::ImpossibleToCollect(tags) => {
+                let report = self.make_report(SessionOutcome::Unfinishable(UnfinishableOutcome(tags)));
+                SessionState::Unfinishable(report)
             }
             AddSessionUpdate::StateDidNotChange => SessionState::InProgress(self),
             AddSessionUpdate::MessageAttributableError(error) => {
@@ -683,8 +677,9 @@ pub enum SessionOutcome<SP: SessionParameters, P: ExecutableProtocol<SP>> {
 }
 
 enum AddSessionUpdate<SP: SessionParameters> {
-    StateChanged,
     StateDidNotChange,
+    ReachedOutput,
+    ImpossibleToCollect(Vec<ScalarTag>),
     MessageAttributableError(MessageAttributableError<SP>),
     SpuriousError { store_in: AnyTag, error: SpuriousError },
 }
@@ -692,8 +687,9 @@ enum AddSessionUpdate<SP: SessionParameters> {
 impl<SP: SessionParameters> From<RulesetStateChange> for AddSessionUpdate<SP> {
     fn from(source: RulesetStateChange) -> Self {
         match source {
-            RulesetStateChange::Changed => Self::StateChanged,
             RulesetStateChange::NotChanged => Self::StateDidNotChange,
+            RulesetStateChange::ReachedOutput => Self::ReachedOutput,
+            RulesetStateChange::ImpossibleToCollect(tags) => Self::ImpossibleToCollect(tags),
         }
     }
 }

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -11,13 +11,13 @@ use super::session::SessionData;
 use crate::{
     entities::{
         AnyTag, Args, ComputedMappingTag, ComputedScalarTag, DeserializeArgs, DeserializeFunction, LocalSignedBCTag,
-        LocalSignedDMTag, MappingTag, MaybeAttributableError, Message, MessageId, ReceivedTag, RemoteSignedTag,
-        RuntimeError, ScalarTag, SenderAttributableMappingFunction, SenderAttributableWithRevealMappingFunction,
-        SenderError, SenderErrorWithReveal, SerializeAndSignBCFunction, SerializeAndSignDMFunction, SerializeArgs,
-        SignedValue, SpuriousError, ThirdPartyAttributableMappingFunction, ThirdPartyAttributableScalarFunction,
-        ThirdPartyError, UnattributableError, UnattributableMappingFunction, UnattributableMappingFunctionWithRng,
-        UnattributableOptionalScalarFunction, UnattributableScalarFunction, UnattributableScalarFunctionWithRng, Value,
-        VerificationError,
+        LocalSignedDMTag, MappingFunction, MappingTag, MaybeAttributableError, Message, MessageId, ReceivedTag,
+        RemoteSignedTag, RuntimeError, ScalarFunction, ScalarTag, SenderAttributableMappingFunction,
+        SenderAttributableWithRevealMappingFunction, SenderError, SenderErrorWithReveal, SerializeAndSignBCFunction,
+        SerializeAndSignDMFunction, SerializeArgs, SignedValue, SpuriousError, ThirdPartyAttributableMappingFunction,
+        ThirdPartyAttributableScalarFunction, ThirdPartyError, UnattributableError, UnattributableMappingFunction,
+        UnattributableMappingFunctionWithRng, UnattributableOptionalScalarFunction, UnattributableScalarFunction,
+        UnattributableScalarFunctionWithRng, Value, VerificationError,
     },
     flat_representation::OnError,
     traits::SessionParameters,
@@ -785,6 +785,53 @@ pub enum Task<SP: SessionParameters> {
     Deterministic(DeterministicTask<SP>),
     /// Perform a computation that needs access to an RNG.
     Randomized(RandomizedTask<SP>),
+}
+
+impl<SP: SessionParameters> Task<SP> {
+    pub(crate) fn from_scalar_function(
+        store_in: ComputedScalarTag,
+        function: ScalarFunction<SP>,
+        args: Args<SP>,
+    ) -> Self {
+        match function {
+            ScalarFunction::Unattributable(function) => ScalarUnattributableTask::new(store_in, function, args).into(),
+            ScalarFunction::UnattributableOptional(function) => {
+                ScalarUnattributableOptionalTask::new(store_in, function, args).into()
+            }
+            ScalarFunction::UnattributableWithRng(function) => {
+                RngScalarUnattributableTask::new(store_in, function, args).into()
+            }
+            ScalarFunction::ThirdPartyAttributable(function) => {
+                ScalarThirdPartyAttributableTask::new(store_in, function, args).into()
+            }
+        }
+    }
+
+    pub(crate) fn from_mapping_function(
+        store_in: ComputedMappingTag,
+        function: MappingFunction<SP>,
+        index: SP::Verifier,
+        args: Args<SP>,
+        on_error: OnError,
+    ) -> Self {
+        match function {
+            MappingFunction::Unattributable(function) => {
+                ElementUnattributableTask::new(store_in, function, index, args).into()
+            }
+            MappingFunction::UnattributableWithRng(function) => {
+                RngElementUnattributableTask::new(store_in, function, index, args).into()
+            }
+            MappingFunction::SenderAttributable(function) => {
+                ElementSenderAttributableTask::new(store_in, function, index, args, on_error).into()
+            }
+            MappingFunction::SenderAttributableWithReveal(function) => {
+                ElementSenderAttributableWithRevealTask::new(store_in, function, index, args, on_error).into()
+            }
+            MappingFunction::ThirdPartyAttributable(function) => {
+                ElementThirdPartyAttributableTask::new(store_in, function, index, args).into()
+            }
+        }
+    }
 }
 
 /// The result of executing a task, to be passed to [`Session::with_update`].

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -11,8 +11,8 @@ use super::{session::SessionData, storage::Storage};
 use crate::{
     entities::{
         AnyTag, Args, ComputedMappingTag, ComputedScalarTag, DeserializeArgs, DeserializeFunction, LocalSignedBCTag,
-        LocalSignedDMTag, MappingFunction, MappingTag, MaybeAttributableError, Message, MessageId, ReceivedTag,
-        RemoteSignedTag, RuntimeError, ScalarFunction, ScalarTag, SenderAttributableMappingFunction,
+        LocalSignedDMTag, MappingFunction, MappingTag, MaybeAttributableError, MergedScalarTag, Message, MessageId,
+        ReceivedTag, RemoteSignedTag, RuntimeError, ScalarFunction, ScalarTag, SenderAttributableMappingFunction,
         SenderAttributableWithRevealMappingFunction, SenderError, SenderErrorWithReveal, SentBCTag, SentDMTag,
         SerializeAndSignBCFunction, SerializeAndSignDMFunction, SerializeArgs, SessionId, SignedValue, SpuriousError,
         ThirdPartyAttributableMappingFunction, ThirdPartyAttributableScalarFunction, ThirdPartyError,
@@ -21,8 +21,9 @@ use crate::{
         VerificationError,
     },
     flat_representation::{
-        ComputeDeserializeElementAction, ComputeMappingElementAction, ComputeScalarAction,
-        ComputeSerializeAndSignElementAction, ComputeSerializeAndSignScalarAction, OnError, SendBCAction, SendDMAction,
+        CollectAction, ComputeDeserializeElementAction, ComputeMappingElementAction, ComputeScalarAction,
+        ComputeSerializeAndSignElementAction, ComputeSerializeAndSignScalarAction, MergeScalarsAction, OnError,
+        SendBCAction, SendDMAction,
     },
     traced_error::TraceableResult,
     traits::SessionParameters,
@@ -775,6 +776,74 @@ impl<SP: SessionParameters> From<PreprocessMessageTask<SP>> for Task<SP> {
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct MergeScalarsTask {
+    store_in: MergedScalarTag,
+    result: Value,
+}
+
+impl MergeScalarsTask {
+    fn new<SP: SessionParameters>(
+        storage: &Storage<SP::Verifier>,
+        action: MergeScalarsAction,
+    ) -> Result<Self, RuntimeError> {
+        let result = storage
+            .get_one_or_both_as_value(&action.left, &action.right)
+            .or_with_context(|| format!("Failed to get the argument for `{}` from storage", action.store_in))?;
+        Ok(Self {
+            store_in: action.store_in,
+            result,
+        })
+    }
+
+    fn execute<SP: SessionParameters>(self) -> SessionUpdate<SP> {
+        SessionUpdate(SessionUpdateEnum::MergedScalars {
+            store_in: self.store_in,
+            result: self.result,
+        })
+    }
+}
+
+impl<SP: SessionParameters> From<MergeScalarsTask> for Task<SP> {
+    fn from(source: MergeScalarsTask) -> Self {
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::MergeScalars(source)))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CollectTask {
+    store_in: ScalarTag,
+    result: Value,
+}
+
+impl CollectTask {
+    fn new<SP: SessionParameters>(
+        storage: &Storage<SP::Verifier>,
+        action: CollectAction<SP>,
+    ) -> Result<Self, RuntimeError> {
+        let result = storage
+            .get_mapping_as_value(&action.values, &action.sources)
+            .or_with_context(|| format!("Failed to get the argument for `{}` from storage", action.store_in))?;
+        Ok(Self {
+            store_in: action.store_in,
+            result,
+        })
+    }
+
+    fn execute<SP: SessionParameters>(self) -> SessionUpdate<SP> {
+        SessionUpdate(SessionUpdateEnum::Collected {
+            store_in: self.store_in,
+            result: self.result,
+        })
+    }
+}
+
+impl<SP: SessionParameters> From<CollectTask> for Task<SP> {
+    fn from(source: CollectTask) -> Self {
+        Self::Deterministic(DeterministicTask(DeterministicTaskEnum::Collect(source)))
+    }
+}
+
 #[derive_where::derive_where(Debug)]
 enum DeterministicTaskEnum<SP: SessionParameters> {
     ScalarUnattributable(ScalarUnattributableTask<SP>),
@@ -786,6 +855,8 @@ enum DeterministicTaskEnum<SP: SessionParameters> {
     ElementThirdPartyAttributable(ElementThirdPartyAttributableTask<SP>),
     DeserializeElement(DeserializeElementTask<SP>),
     PreprocessMessage(PreprocessMessageTask<SP>),
+    MergeScalars(MergeScalarsTask),
+    Collect(CollectTask),
 }
 
 /// An object encapsulating a deterministic task (one that does not require an RNG).
@@ -805,6 +876,8 @@ impl<SP: SessionParameters> DeterministicTask<SP> {
             DeterministicTaskEnum::ElementThirdPartyAttributable(task) => task.execute(),
             DeterministicTaskEnum::DeserializeElement(task) => task.execute(),
             DeterministicTaskEnum::PreprocessMessage(task) => task.execute(),
+            DeterministicTaskEnum::MergeScalars(task) => task.execute(),
+            DeterministicTaskEnum::Collect(task) => task.execute(),
         }
     }
 }
@@ -961,6 +1034,19 @@ impl<SP: SessionParameters> Task<SP> {
     ) -> Result<Self, RuntimeError> {
         Ok(SendTask::from_send_dm_action(storage, action)?.into())
     }
+
+    pub(crate) fn from_merge_scalars_action(
+        storage: &Storage<SP::Verifier>,
+        action: MergeScalarsAction,
+    ) -> Result<Self, RuntimeError> {
+        Ok(MergeScalarsTask::new::<SP>(storage, action)?.into())
+    }
+    pub(crate) fn from_collect_action(
+        storage: &Storage<SP::Verifier>,
+        action: CollectAction<SP>,
+    ) -> Result<Self, RuntimeError> {
+        Ok(CollectTask::new(storage, action)?.into())
+    }
 }
 
 /// The result of executing a task, to be passed to [`Session::with_update`].
@@ -1047,5 +1133,13 @@ pub(crate) enum SessionUpdateEnum<SP: SessionParameters> {
     ExternalBan {
         party_id: SP::Verifier,
         reason: String,
+    },
+    MergedScalars {
+        store_in: MergedScalarTag,
+        result: Value,
+    },
+    Collected {
+        store_in: ScalarTag,
+        result: Value,
     },
 }

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -7,19 +7,24 @@ use alloc::{
     vec::Vec,
 };
 
-use super::session::SessionData;
+use super::{session::SessionData, storage::Storage};
 use crate::{
     entities::{
         AnyTag, Args, ComputedMappingTag, ComputedScalarTag, DeserializeArgs, DeserializeFunction, LocalSignedBCTag,
         LocalSignedDMTag, MappingFunction, MappingTag, MaybeAttributableError, Message, MessageId, ReceivedTag,
         RemoteSignedTag, RuntimeError, ScalarFunction, ScalarTag, SenderAttributableMappingFunction,
         SenderAttributableWithRevealMappingFunction, SenderError, SenderErrorWithReveal, SerializeAndSignBCFunction,
-        SerializeAndSignDMFunction, SerializeArgs, SignedValue, SpuriousError, ThirdPartyAttributableMappingFunction,
-        ThirdPartyAttributableScalarFunction, ThirdPartyError, UnattributableError, UnattributableMappingFunction,
-        UnattributableMappingFunctionWithRng, UnattributableOptionalScalarFunction, UnattributableScalarFunction,
-        UnattributableScalarFunctionWithRng, Value, VerificationError,
+        SerializeAndSignDMFunction, SerializeArgs, SessionId, SignedValue, SpuriousError,
+        ThirdPartyAttributableMappingFunction, ThirdPartyAttributableScalarFunction, ThirdPartyError,
+        UnattributableError, UnattributableMappingFunction, UnattributableMappingFunctionWithRng,
+        UnattributableOptionalScalarFunction, UnattributableScalarFunction, UnattributableScalarFunctionWithRng, Value,
+        VerificationError,
     },
-    flat_representation::OnError,
+    flat_representation::{
+        ComputeDeserializeElementAction, ComputeMappingElementAction, ComputeScalarAction,
+        ComputeSerializeAndSignElementAction, ComputeSerializeAndSignScalarAction, OnError, SendBCAction, SendDMAction,
+    },
+    traced_error::TraceableResult,
     traits::SessionParameters,
 };
 
@@ -562,18 +567,36 @@ pub struct SendTask<SP: SessionParameters> {
 }
 
 impl<SP: SessionParameters> SendTask<SP> {
-    pub(crate) fn new_broadcast(destinations: BTreeSet<SP::Verifier>, value: SignedValue<SP>) -> Self {
-        Self {
+    pub(crate) fn from_send_bc_action(
+        storage: &Storage<SP::Verifier>,
+        action: SendBCAction<SP>,
+    ) -> Result<Self, RuntimeError> {
+        let value = storage
+            .get_scalar(&ScalarTag::from(action.to_send))
+            .or_with_context(|| format!("Failed to get the argument for `{}` from storage", action.store_in))?;
+        let signed_value = value
+            .downcast::<SignedValue<SP>>()
+            .or_with_context(|| "Failed to downcast the value to be sent".into())?;
+        Ok(Self {
             direct_messages: BTreeMap::new(),
-            broadcast_messages: vec![(destinations, value)],
-        }
+            broadcast_messages: vec![(action.destinations, signed_value)],
+        })
     }
 
-    pub(crate) fn new_direct(destination: SP::Verifier, value: SignedValue<SP>) -> Self {
-        Self {
-            direct_messages: [(destination, value)].into(),
+    pub(crate) fn from_send_dm_action(
+        storage: &Storage<SP::Verifier>,
+        action: SendDMAction<SP>,
+    ) -> Result<Self, RuntimeError> {
+        let value = storage
+            .get_elem(&MappingTag::from(action.to_send), &action.destination)
+            .or_with_context(|| format!("Failed to get the argument for `{}` from storage", action.store_in))?;
+        let signed_value = value
+            .downcast::<SignedValue<SP>>()
+            .or_with_context(|| "Failed to downcast the value to be sent".into())?;
+        Ok(Self {
+            direct_messages: [(action.destination, signed_value)].into(),
             broadcast_messages: Vec::new(),
-        }
+        })
     }
 
     /// Converts the task into separated broadcasts and direct messages.
@@ -788,49 +811,121 @@ pub enum Task<SP: SessionParameters> {
 }
 
 impl<SP: SessionParameters> Task<SP> {
-    pub(crate) fn from_scalar_function(
-        store_in: ComputedScalarTag,
-        function: ScalarFunction<SP>,
-        args: Args<SP>,
-    ) -> Self {
-        match function {
-            ScalarFunction::Unattributable(function) => ScalarUnattributableTask::new(store_in, function, args).into(),
+    pub(crate) fn from_compute_scalar_action(
+        session_id: &SessionId<SP>,
+        session_verifier: &SP::Verifier,
+        storage: &Storage<SP::Verifier>,
+        action: ComputeScalarAction<SP>,
+    ) -> Result<Self, RuntimeError> {
+        let arg_values = storage
+            .get_scalar_args(action.args)
+            .or_with_context(|| format!("Failed to get the arguments for `{}` from storage", action.store_in))?;
+        let args = Args::new(session_id, session_verifier, arg_values);
+
+        Ok(match action.function {
+            ScalarFunction::Unattributable(function) => {
+                ScalarUnattributableTask::new(action.store_in, function, args).into()
+            }
             ScalarFunction::UnattributableOptional(function) => {
-                ScalarUnattributableOptionalTask::new(store_in, function, args).into()
+                ScalarUnattributableOptionalTask::new(action.store_in, function, args).into()
             }
             ScalarFunction::UnattributableWithRng(function) => {
-                RngScalarUnattributableTask::new(store_in, function, args).into()
+                RngScalarUnattributableTask::new(action.store_in, function, args).into()
             }
             ScalarFunction::ThirdPartyAttributable(function) => {
-                ScalarThirdPartyAttributableTask::new(store_in, function, args).into()
+                ScalarThirdPartyAttributableTask::new(action.store_in, function, args).into()
             }
-        }
+        })
     }
 
-    pub(crate) fn from_mapping_function(
-        store_in: ComputedMappingTag,
-        function: MappingFunction<SP>,
-        index: SP::Verifier,
-        args: Args<SP>,
-        on_error: OnError,
-    ) -> Self {
-        match function {
+    pub(crate) fn from_compute_mapping_element_action(
+        session_id: &SessionId<SP>,
+        session_verifier: &SP::Verifier,
+        storage: &Storage<SP::Verifier>,
+        action: ComputeMappingElementAction<SP>,
+    ) -> Result<Self, RuntimeError> {
+        let arg_values = storage
+            .get_scalar_or_mapping_args(&action.index, action.args)
+            .or_with_context(|| format!("Failed to get the arguments for `{}` from storage", action.store_in))?;
+        let args = Args::new(session_id, session_verifier, arg_values);
+        Ok(match action.function {
             MappingFunction::Unattributable(function) => {
-                ElementUnattributableTask::new(store_in, function, index, args).into()
+                ElementUnattributableTask::new(action.store_in, function, action.index, args).into()
             }
             MappingFunction::UnattributableWithRng(function) => {
-                RngElementUnattributableTask::new(store_in, function, index, args).into()
+                RngElementUnattributableTask::new(action.store_in, function, action.index, args).into()
             }
             MappingFunction::SenderAttributable(function) => {
-                ElementSenderAttributableTask::new(store_in, function, index, args, on_error).into()
+                ElementSenderAttributableTask::new(action.store_in, function, action.index, args, action.on_error)
+                    .into()
             }
-            MappingFunction::SenderAttributableWithReveal(function) => {
-                ElementSenderAttributableWithRevealTask::new(store_in, function, index, args, on_error).into()
-            }
+            MappingFunction::SenderAttributableWithReveal(function) => ElementSenderAttributableWithRevealTask::new(
+                action.store_in,
+                function,
+                action.index,
+                args,
+                action.on_error,
+            )
+            .into(),
             MappingFunction::ThirdPartyAttributable(function) => {
-                ElementThirdPartyAttributableTask::new(store_in, function, index, args).into()
+                ElementThirdPartyAttributableTask::new(action.store_in, function, action.index, args).into()
             }
+        })
+    }
+
+    pub(crate) fn from_compute_serialize_and_sign_scalar_action(
+        signer: &Arc<SP::Signer>,
+        session_id: &SessionId<SP>,
+        storage: &Storage<SP::Verifier>,
+        action: ComputeSerializeAndSignScalarAction<SP>,
+    ) -> Result<Self, RuntimeError> {
+        let value = storage
+            .get_scalar(&action.data)
+            .or_with_context(|| format!("Failed to get the argument for `{}` from storage", action.data))?;
+
+        let args = SerializeArgs::new(signer, session_id, action.message_name, action.serde_adapter, value);
+        Ok(SerializeAndSignScalarTask::new(action.store_in, action.function, args).into())
+    }
+
+    pub(crate) fn from_compute_serialize_and_sign_element_action(
+        signer: &Arc<SP::Signer>,
+        session_id: &SessionId<SP>,
+        storage: &Storage<SP::Verifier>,
+        action: ComputeSerializeAndSignElementAction<SP>,
+    ) -> Result<Self, RuntimeError> {
+        let value = match action.data {
+            AnyTag::Scalar(tag) => storage.get_scalar(&tag),
+            AnyTag::Mapping(tag) => storage.get_elem(&tag, &action.index),
         }
+        .or_with_context(|| format!("Failed to get the argument for `{}` from storage", action.store_in))?;
+
+        let args = SerializeArgs::new(signer, session_id, action.message_name, action.serde_adapter, value);
+        Ok(SerializeAndSignElementTask::new(action.store_in, action.function, action.index, args).into())
+    }
+
+    pub(crate) fn from_compute_deserialize_element_action(
+        storage: &Storage<SP::Verifier>,
+        action: ComputeDeserializeElementAction<SP>,
+    ) -> Result<Self, RuntimeError> {
+        let value = storage
+            .get_elem(&MappingTag::from(action.data), &action.index)
+            .or_with_context(|| format!("Failed to get the argument for `{}` from storage", action.store_in))?;
+        let args = DeserializeArgs::new(&action.expected_senders, action.serde_adapter, value);
+        Ok(DeserializeElementTask::new(action.store_in, action.function, action.index, args, action.on_error).into())
+    }
+
+    pub(crate) fn from_send_bc_action(
+        storage: &Storage<SP::Verifier>,
+        action: SendBCAction<SP>,
+    ) -> Result<Self, RuntimeError> {
+        Ok(SendTask::from_send_bc_action(storage, action)?.into())
+    }
+
+    pub(crate) fn from_send_dm_action(
+        storage: &Storage<SP::Verifier>,
+        action: SendDMAction<SP>,
+    ) -> Result<Self, RuntimeError> {
+        Ok(SendTask::from_send_dm_action(storage, action)?.into())
     }
 }
 

--- a/ayatori/src/execution/task.rs
+++ b/ayatori/src/execution/task.rs
@@ -13,8 +13,8 @@ use crate::{
         AnyTag, Args, ComputedMappingTag, ComputedScalarTag, DeserializeArgs, DeserializeFunction, LocalSignedBCTag,
         LocalSignedDMTag, MappingFunction, MappingTag, MaybeAttributableError, Message, MessageId, ReceivedTag,
         RemoteSignedTag, RuntimeError, ScalarFunction, ScalarTag, SenderAttributableMappingFunction,
-        SenderAttributableWithRevealMappingFunction, SenderError, SenderErrorWithReveal, SerializeAndSignBCFunction,
-        SerializeAndSignDMFunction, SerializeArgs, SessionId, SignedValue, SpuriousError,
+        SenderAttributableWithRevealMappingFunction, SenderError, SenderErrorWithReveal, SentBCTag, SentDMTag,
+        SerializeAndSignBCFunction, SerializeAndSignDMFunction, SerializeArgs, SessionId, SignedValue, SpuriousError,
         ThirdPartyAttributableMappingFunction, ThirdPartyAttributableScalarFunction, ThirdPartyError,
         UnattributableError, UnattributableMappingFunction, UnattributableMappingFunctionWithRng,
         UnattributableOptionalScalarFunction, UnattributableScalarFunction, UnattributableScalarFunctionWithRng, Value,
@@ -562,8 +562,29 @@ impl<SP: SessionParameters> From<SerializeAndSignElementTask<SP>> for Task<SP> {
 /// Can be converted into different types of messages, depending on what transport capabilities are available.
 #[derive_where::derive_where(Debug)]
 pub struct SendTask<SP: SessionParameters> {
+    kind: SendTaskKind<SP>,
     direct_messages: BTreeMap<SP::Verifier, SignedValue<SP>>,
     broadcast_messages: Vec<(BTreeSet<SP::Verifier>, SignedValue<SP>)>,
+}
+
+#[derive_where::derive_where(Debug)]
+enum SendTaskKind<SP: SessionParameters> {
+    BroadcastMessage {
+        store_in: SentBCTag,
+    },
+    DirectMessage {
+        store_in: SentDMTag,
+        destination: SP::Verifier,
+    },
+}
+
+impl<SP: SessionParameters> SendTaskKind<SP> {
+    fn into_update(self) -> SessionUpdate<SP> {
+        SessionUpdate(match self {
+            Self::BroadcastMessage { store_in } => SessionUpdateEnum::SentBC { store_in },
+            Self::DirectMessage { store_in, destination } => SessionUpdateEnum::SentDM { store_in, destination },
+        })
+    }
 }
 
 impl<SP: SessionParameters> SendTask<SP> {
@@ -578,6 +599,9 @@ impl<SP: SessionParameters> SendTask<SP> {
             .downcast::<SignedValue<SP>>()
             .or_with_context(|| "Failed to downcast the value to be sent".into())?;
         Ok(Self {
+            kind: SendTaskKind::BroadcastMessage {
+                store_in: action.store_in,
+            },
             direct_messages: BTreeMap::new(),
             broadcast_messages: vec![(action.destinations, signed_value)],
         })
@@ -594,6 +618,10 @@ impl<SP: SessionParameters> SendTask<SP> {
             .downcast::<SignedValue<SP>>()
             .or_with_context(|| "Failed to downcast the value to be sent".into())?;
         Ok(Self {
+            kind: SendTaskKind::DirectMessage {
+                store_in: action.store_in,
+                destination: action.destination.clone(),
+            },
             direct_messages: [(action.destination, signed_value)].into(),
             broadcast_messages: Vec::new(),
         })
@@ -605,11 +633,13 @@ impl<SP: SessionParameters> SendTask<SP> {
         self,
     ) -> Result<
         (
+            SessionUpdate<SP>,
             Vec<(BTreeSet<SP::Verifier>, Message<SP>)>,
             BTreeMap<SP::Verifier, Message<SP>>,
         ),
         RuntimeError,
     > {
+        let update = self.kind.into_update();
         let dms = self
             .direct_messages
             .into_iter()
@@ -620,11 +650,13 @@ impl<SP: SessionParameters> SendTask<SP> {
             .into_iter()
             .map(|(destinations, value)| Message::new(vec![value]).map(|message| (destinations, message)))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok((bcs, dms))
+        Ok((update, bcs, dms))
     }
 
     /// Converts the task into purely direct messages for each destination.
-    pub fn into_dms(self) -> Result<BTreeMap<SP::Verifier, Message<SP>>, RuntimeError> {
+    #[expect(clippy::type_complexity)]
+    pub fn into_dms(self) -> Result<(SessionUpdate<SP>, BTreeMap<SP::Verifier, Message<SP>>), RuntimeError> {
+        let update = self.kind.into_update();
         let mut result = self
             .direct_messages
             .into_iter()
@@ -637,10 +669,12 @@ impl<SP: SessionParameters> SendTask<SP> {
             }
         }
 
-        result
+        let dms = result
             .into_iter()
             .map(|(destination, values)| Message::new(values).map(|message| (destination, message)))
-            .collect::<Result<BTreeMap<_, _>, _>>()
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
+
+        Ok((update, dms))
     }
 }
 
@@ -960,6 +994,13 @@ impl<SP: SessionParameters> SessionUpdate<SP> {
 #[derive_where::derive_where(Debug)]
 pub(crate) enum SessionUpdateEnum<SP: SessionParameters> {
     NoActionNeeded,
+    SentBC {
+        store_in: SentBCTag,
+    },
+    SentDM {
+        store_in: SentDMTag,
+        destination: SP::Verifier,
+    },
     Received {
         id: MessageId<SP>,
         message: Message<SP>,

--- a/ayatori/src/execution/tokio.rs
+++ b/ayatori/src/execution/tokio.rs
@@ -44,12 +44,13 @@ where
                     Task::Deterministic(task) => task.execute(),
                     Task::Randomized(task) => task.execute(rng),
                     Task::Send(task) => {
-                        for message_out in C::send_task_into_messages_out(task)? {
+                        let (update, iter) = C::send_task_into_messages_out(task)?;
+                        for message_out in iter {
                             tx.send(message_out).await.map_err(|err| {
                                 RuntimeError::new(format!("Failed to send a message to the output channel: {err}"))
                             })?;
                         }
-                        continue;
+                        update
                     }
                 }
             } else {
@@ -166,11 +167,13 @@ where
                     tasks.spawn_blocking(move || Ok(task.execute(&mut task_rng)));
                 }
                 Task::Send(task) => {
-                    for message_out in C::send_task_into_messages_out(task)? {
+                    let (update, iter) = C::send_task_into_messages_out(task)?;
+                    for message_out in iter {
                         tx.send(message_out).await.map_err(|err| {
                             RuntimeError::new(format!("Failed to send a message to the outbound channel: {err}"))
                         })?;
                     }
+                    tasks.spawn_blocking(move || Ok(update));
                 }
             }
         }

--- a/ayatori/src/flat_representation.rs
+++ b/ayatori/src/flat_representation.rs
@@ -1,6 +1,8 @@
+mod actions;
 mod conditions;
 mod rules;
 mod ruleset;
 
-pub(crate) use rules::{Action, OnError};
+pub(crate) use actions::Action;
+pub(crate) use rules::OnError;
 pub(crate) use ruleset::{Ruleset, RulesetState};

--- a/ayatori/src/flat_representation.rs
+++ b/ayatori/src/flat_representation.rs
@@ -9,4 +9,4 @@ pub(crate) use actions::{
     SendDMAction,
 };
 pub(crate) use rules::OnError;
-pub(crate) use ruleset::{Ruleset, RulesetState, RulesetStateChange};
+pub(crate) use ruleset::{Ruleset, RulesetStateChange};

--- a/ayatori/src/flat_representation.rs
+++ b/ayatori/src/flat_representation.rs
@@ -9,4 +9,4 @@ pub(crate) use actions::{
     SendDMAction,
 };
 pub(crate) use rules::OnError;
-pub(crate) use ruleset::{Ruleset, RulesetState};
+pub(crate) use ruleset::{Ruleset, RulesetState, RulesetStateChange};

--- a/ayatori/src/flat_representation.rs
+++ b/ayatori/src/flat_representation.rs
@@ -4,8 +4,9 @@ mod rules;
 mod ruleset;
 
 pub(crate) use actions::{
-    Action, ComputeDeserializeElementAction, ComputeMappingElementAction, ComputeScalarAction,
-    ComputeSerializeAndSignElementAction, ComputeSerializeAndSignScalarAction, SendBCAction, SendDMAction,
+    Action, CollectAction, ComputeDeserializeElementAction, ComputeMappingElementAction, ComputeScalarAction,
+    ComputeSerializeAndSignElementAction, ComputeSerializeAndSignScalarAction, MergeScalarsAction, SendBCAction,
+    SendDMAction,
 };
 pub(crate) use rules::OnError;
 pub(crate) use ruleset::{Ruleset, RulesetState};

--- a/ayatori/src/flat_representation.rs
+++ b/ayatori/src/flat_representation.rs
@@ -3,6 +3,9 @@ mod conditions;
 mod rules;
 mod ruleset;
 
-pub(crate) use actions::Action;
+pub(crate) use actions::{
+    Action, ComputeDeserializeElementAction, ComputeMappingElementAction, ComputeScalarAction,
+    ComputeSerializeAndSignElementAction, ComputeSerializeAndSignScalarAction, SendBCAction, SendDMAction,
+};
 pub(crate) use rules::OnError;
 pub(crate) use ruleset::{Ruleset, RulesetState};

--- a/ayatori/src/flat_representation/actions.rs
+++ b/ayatori/src/flat_representation/actions.rs
@@ -81,7 +81,7 @@ pub(crate) struct CollectAction<SP: SessionParameters> {
 }
 
 #[derive(Debug)]
-pub(crate) struct MergeScalarAction {
+pub(crate) struct MergeScalarsAction {
     pub(crate) store_in: MergedScalarTag,
     pub(crate) left: ScalarTag,
     pub(crate) right: ScalarTag,
@@ -97,5 +97,5 @@ pub(crate) enum Action<SP: SessionParameters> {
     SendBC(SendBCAction<SP>),
     SendDM(SendDMAction<SP>),
     Collect(CollectAction<SP>),
-    MergeScalar(MergeScalarAction),
+    MergeScalar(MergeScalarsAction),
 }

--- a/ayatori/src/flat_representation/actions.rs
+++ b/ayatori/src/flat_representation/actions.rs
@@ -1,0 +1,101 @@
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    string::String,
+};
+
+use super::rules::OnError;
+use crate::{
+    entities::{
+        AnyTag, ComputedMappingTag, ComputedScalarTag, DeserializeFunction, FullName, LocalSignedBCTag,
+        LocalSignedDMTag, MappingFunction, MappingTag, MergedScalarTag, ReceivedTag, RemoteSignedTag, ScalarFunction,
+        ScalarTag, SentBCTag, SentDMTag, SerdeAdapter, SerializeAndSignBCFunction, SerializeAndSignDMFunction,
+    },
+    traits::SessionParameters,
+};
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct ComputeScalarAction<SP: SessionParameters> {
+    pub(crate) store_in: ComputedScalarTag,
+    pub(crate) function: ScalarFunction<SP>,
+    pub(crate) args: BTreeMap<String, ScalarTag>,
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct ComputeMappingElementAction<SP: SessionParameters> {
+    pub(crate) store_in: ComputedMappingTag,
+    pub(crate) index: SP::Verifier,
+    pub(crate) function: MappingFunction<SP>,
+    pub(crate) args: BTreeMap<String, AnyTag>,
+    pub(crate) on_error: OnError,
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct ComputeSerializeAndSignScalarAction<SP: SessionParameters> {
+    pub(crate) store_in: LocalSignedBCTag,
+    pub(crate) function: SerializeAndSignBCFunction<SP>,
+    pub(crate) data: ScalarTag,
+    pub(crate) message_name: FullName,
+    pub(crate) serde_adapter: SerdeAdapter<SP::WireFormat>,
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct ComputeSerializeAndSignElementAction<SP: SessionParameters> {
+    pub(crate) store_in: LocalSignedDMTag,
+    pub(crate) index: SP::Verifier,
+    pub(crate) function: SerializeAndSignDMFunction<SP>,
+    pub(crate) data: AnyTag,
+    pub(crate) message_name: FullName,
+    pub(crate) serde_adapter: SerdeAdapter<SP::WireFormat>,
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct ComputeDeserializeElementAction<SP: SessionParameters> {
+    pub(crate) store_in: ReceivedTag,
+    pub(crate) index: SP::Verifier,
+    pub(crate) function: DeserializeFunction<SP>,
+    pub(crate) data: RemoteSignedTag,
+    pub(crate) serde_adapter: SerdeAdapter<SP::WireFormat>,
+    pub(crate) expected_senders: BTreeSet<SP::Verifier>,
+    pub(crate) on_error: OnError,
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct SendBCAction<SP: SessionParameters> {
+    pub(crate) store_in: SentBCTag,
+    pub(crate) to_send: LocalSignedBCTag,
+    pub(crate) destinations: BTreeSet<SP::Verifier>,
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct SendDMAction<SP: SessionParameters> {
+    pub(crate) store_in: SentDMTag,
+    pub(crate) to_send: LocalSignedDMTag,
+    pub(crate) destination: SP::Verifier,
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) struct CollectAction<SP: SessionParameters> {
+    pub(crate) store_in: ScalarTag,
+    pub(crate) values: MappingTag,
+    pub(crate) sources: BTreeSet<SP::Verifier>,
+}
+
+#[derive(Debug)]
+pub(crate) struct MergeScalarAction {
+    pub(crate) store_in: MergedScalarTag,
+    pub(crate) left: ScalarTag,
+    pub(crate) right: ScalarTag,
+}
+
+#[derive_where::derive_where(Debug)]
+pub(crate) enum Action<SP: SessionParameters> {
+    ComputeScalar(ComputeScalarAction<SP>),
+    ComputeMappingElement(ComputeMappingElementAction<SP>),
+    ComputeSerializeAndSignScalar(ComputeSerializeAndSignScalarAction<SP>),
+    ComputeSerializeAndSignElement(ComputeSerializeAndSignElementAction<SP>),
+    ComputeDeserializeElement(ComputeDeserializeElementAction<SP>),
+    SendBC(SendBCAction<SP>),
+    SendDM(SendDMAction<SP>),
+    Collect(CollectAction<SP>),
+    MergeScalar(MergeScalarAction),
+}

--- a/ayatori/src/flat_representation/rules.rs
+++ b/ayatori/src/flat_representation/rules.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use super::{
     actions::{
         Action, CollectAction, ComputeDeserializeElementAction, ComputeMappingElementAction, ComputeScalarAction,
-        ComputeSerializeAndSignElementAction, ComputeSerializeAndSignScalarAction, MergeScalarAction, SendBCAction,
+        ComputeSerializeAndSignElementAction, ComputeSerializeAndSignScalarAction, MergeScalarsAction, SendBCAction,
         SendDMAction,
     },
     conditions::{
@@ -154,7 +154,7 @@ impl<SP: SessionParameters> ScalarRule<SP> {
                 serde_adapter,
             }),
             ScalarRuleKind::Merge { store_in, left, right } => {
-                Action::MergeScalar(MergeScalarAction { store_in, left, right })
+                Action::MergeScalar(MergeScalarsAction { store_in, left, right })
             }
         }
     }

--- a/ayatori/src/flat_representation/rules.rs
+++ b/ayatori/src/flat_representation/rules.rs
@@ -6,9 +6,16 @@ use core::fmt::{self, Display};
 
 use itertools::Itertools;
 
-use super::conditions::{
-    ElementCondition, ElementConditionWithState, QuorumCondition, QuorumConditionWithState, ScalarCondition,
-    ScalarConditionWithState,
+use super::{
+    actions::{
+        Action, CollectAction, ComputeDeserializeElementAction, ComputeMappingElementAction, ComputeScalarAction,
+        ComputeSerializeAndSignElementAction, ComputeSerializeAndSignScalarAction, MergeScalarAction, SendBCAction,
+        SendDMAction,
+    },
+    conditions::{
+        ElementCondition, ElementConditionWithState, QuorumCondition, QuorumConditionWithState, ScalarCondition,
+        ScalarConditionWithState,
+    },
 };
 use crate::{
     entities::{
@@ -22,66 +29,6 @@ use crate::{
     },
     traits::SessionParameters,
 };
-
-#[derive_where::derive_where(Debug)]
-pub(crate) enum Action<SP: SessionParameters> {
-    ComputeScalar {
-        store_in: ComputedScalarTag,
-        function: ScalarFunction<SP>,
-        args: BTreeMap<String, ScalarTag>,
-    },
-    ComputeMappingElement {
-        store_in: ComputedMappingTag,
-        index: SP::Verifier,
-        function: MappingFunction<SP>,
-        args: BTreeMap<String, AnyTag>,
-        on_error: OnError,
-    },
-    ComputeSerializeAndSignScalar {
-        store_in: LocalSignedBCTag,
-        function: SerializeAndSignBCFunction<SP>,
-        data: ScalarTag,
-        message_name: FullName,
-        serde_adapter: SerdeAdapter<SP::WireFormat>,
-    },
-    ComputeSerializeAndSignElement {
-        store_in: LocalSignedDMTag,
-        index: SP::Verifier,
-        function: SerializeAndSignDMFunction<SP>,
-        data: AnyTag,
-        message_name: FullName,
-        serde_adapter: SerdeAdapter<SP::WireFormat>,
-    },
-    ComputeDeserializeElement {
-        store_in: ReceivedTag,
-        index: SP::Verifier,
-        function: DeserializeFunction<SP>,
-        data: RemoteSignedTag,
-        serde_adapter: SerdeAdapter<SP::WireFormat>,
-        expected_senders: BTreeSet<SP::Verifier>,
-        on_error: OnError,
-    },
-    SendBC {
-        store_in: SentBCTag,
-        to_send: LocalSignedBCTag,
-        destinations: BTreeSet<SP::Verifier>,
-    },
-    SendDM {
-        store_in: SentDMTag,
-        to_send: LocalSignedDMTag,
-        destination: SP::Verifier,
-    },
-    Collect {
-        store_in: ScalarTag,
-        values: MappingTag,
-        sources: BTreeSet<SP::Verifier>,
-    },
-    MergeScalar {
-        store_in: MergedScalarTag,
-        left: ScalarTag,
-        right: ScalarTag,
-    },
-}
 
 #[derive(Debug, Clone)]
 pub(crate) enum OnError {
@@ -188,25 +135,27 @@ impl<SP: SessionParameters> ScalarRule<SP> {
                 store_in,
                 function,
                 args,
-            } => Action::ComputeScalar {
+            } => Action::ComputeScalar(ComputeScalarAction {
                 store_in,
                 function,
                 args,
-            },
+            }),
             ScalarRuleKind::SerializeAndSign {
                 store_in,
                 function,
                 data,
                 message_name,
                 serde_adapter,
-            } => Action::ComputeSerializeAndSignScalar {
+            } => Action::ComputeSerializeAndSignScalar(ComputeSerializeAndSignScalarAction {
                 store_in,
                 function,
                 data,
                 message_name,
                 serde_adapter,
-            },
-            ScalarRuleKind::Merge { store_in, left, right } => Action::MergeScalar { store_in, left, right },
+            }),
+            ScalarRuleKind::Merge { store_in, left, right } => {
+                Action::MergeScalar(MergeScalarAction { store_in, left, right })
+            }
         }
     }
 }
@@ -268,11 +217,11 @@ impl<SP: SessionParameters> CollectRule<SP> {
     }
 
     pub fn into_action(self) -> Action<SP> {
-        Action::Collect {
+        Action::Collect(CollectAction {
             store_in: self.store_in,
             values: self.values,
             sources: self.quorum_condition.available_ids(),
-        }
+        })
     }
 }
 
@@ -407,27 +356,27 @@ impl<SP: SessionParameters> MappingRule<SP> {
                 function,
                 args,
                 on_error,
-            } => Action::ComputeMappingElement {
+            } => Action::ComputeMappingElement(ComputeMappingElementAction {
                 store_in: store_in.clone(),
                 index: id,
                 function: function.clone(),
                 args: args.clone(),
                 on_error: on_error.clone(),
-            },
+            }),
             MappingRuleKind::SerializeAndSign {
                 store_in,
                 function,
                 data,
                 message_name,
                 serde_adapter,
-            } => Action::ComputeSerializeAndSignElement {
+            } => Action::ComputeSerializeAndSignElement(ComputeSerializeAndSignElementAction {
                 store_in: store_in.clone(),
                 index: id,
                 function: function.clone(),
                 data: data.clone(),
                 message_name: message_name.clone(),
                 serde_adapter: serde_adapter.clone(),
-            },
+            }),
             MappingRuleKind::Deserialize {
                 store_in,
                 function,
@@ -435,7 +384,7 @@ impl<SP: SessionParameters> MappingRule<SP> {
                 serde_adapter,
                 expected_senders,
                 on_error,
-            } => Action::ComputeDeserializeElement {
+            } => Action::ComputeDeserializeElement(ComputeDeserializeElementAction {
                 store_in: store_in.clone(),
                 index: id,
                 function: function.clone(),
@@ -443,7 +392,7 @@ impl<SP: SessionParameters> MappingRule<SP> {
                 serde_adapter: serde_adapter.clone(),
                 expected_senders: expected_senders.clone(),
                 on_error: on_error.clone(),
-            },
+            }),
         }
     }
 }
@@ -481,11 +430,11 @@ impl<SP: SessionParameters> SendBCRule<SP> {
     }
 
     pub fn into_action(self) -> Action<SP> {
-        Action::SendBC {
+        Action::SendBC(SendBCAction {
             store_in: self.store_in,
             to_send: self.to_send,
             destinations: self.destinations,
-        }
+        })
     }
 }
 
@@ -528,11 +477,11 @@ impl<SP: SessionParameters> SendDMRule<SP> {
     }
 
     pub fn make_action(&self, id: SP::Verifier) -> Action<SP> {
-        Action::SendDM {
+        Action::SendDM(SendDMAction {
             store_in: self.store_in.clone(),
             to_send: self.to_send.clone(),
             destination: id,
-        }
+        })
     }
 }
 

--- a/ayatori/src/flat_representation/ruleset.rs
+++ b/ayatori/src/flat_representation/ruleset.rs
@@ -6,7 +6,10 @@ use alloc::{
 };
 use core::fmt::{self, Display};
 
-use super::rules::{Action, CollectRule, MappingRule, OnError, ScalarRule, SendBCRule, SendDMRule};
+use super::{
+    actions::Action,
+    rules::{CollectRule, MappingRule, OnError, ScalarRule, SendBCRule, SendDMRule},
+};
 use crate::{
     entities::{AnyTagRef, ComputedScalarTag, MappingTag, RuntimeError, ScalarArgumentTag, ScalarTag},
     graph_representation::{AnyNode, GeneralizedNode, OutputNode, Reproducibility},

--- a/ayatori/src/flat_representation/ruleset.rs
+++ b/ayatori/src/flat_representation/ruleset.rs
@@ -105,15 +105,9 @@ impl<SP: SessionParameters> PropagatedGroups<SP> {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum RulesetStateChange {
-    Changed,
-    NotChanged,
-}
-
 #[derive(Debug, Clone)]
-pub(crate) enum RulesetState {
-    InProgress,
+pub(crate) enum RulesetStateChange {
+    NotChanged,
     ReachedOutput,
     ImpossibleToCollect(Vec<ScalarTag>),
 }
@@ -127,7 +121,6 @@ pub(crate) struct Ruleset<SP: SessionParameters> {
     send_bc_rules: Vec<SendBCRule<SP>>,
     send_dm_rules: Vec<SendDMRule<SP>>,
     arguments: BTreeMap<String, ScalarArgumentTag>,
-    state: RulesetState,
 }
 
 impl<SP: SessionParameters> Ruleset<SP> {
@@ -221,7 +214,6 @@ impl<SP: SessionParameters> Ruleset<SP> {
             send_bc_rules,
             send_dm_rules,
             arguments,
-            state: RulesetState::InProgress,
         })
     }
 
@@ -238,22 +230,12 @@ impl<SP: SessionParameters> Ruleset<SP> {
         if impossible_collects.is_empty() {
             RulesetStateChange::NotChanged
         } else {
-            self.state = RulesetState::ImpossibleToCollect(impossible_collects);
-            RulesetStateChange::Changed
+            RulesetStateChange::ImpossibleToCollect(impossible_collects)
         }
     }
 
     #[must_use]
     pub fn update_with_scalar_ready(&mut self, tag: &ScalarTag) -> RulesetStateChange {
-        let state_change = if let ScalarTag::Computed(computed_tag) = tag
-            && computed_tag == &self.output_tag
-        {
-            self.state = RulesetState::ReachedOutput;
-            RulesetStateChange::Changed
-        } else {
-            RulesetStateChange::NotChanged
-        };
-
         for rule in &mut self.scalar_rules {
             rule.update_with_scalar_ready(tag);
         }
@@ -274,7 +256,13 @@ impl<SP: SessionParameters> Ruleset<SP> {
             rule.update_with_scalar_ready(tag);
         }
 
-        state_change
+        if let ScalarTag::Computed(computed_tag) = tag
+            && computed_tag == &self.output_tag
+        {
+            RulesetStateChange::ReachedOutput
+        } else {
+            RulesetStateChange::NotChanged
+        }
     }
 
     pub fn update_with_element_ready(&mut self, tag: &MappingTag, id: &SP::Verifier) {
@@ -342,10 +330,6 @@ impl<SP: SessionParameters> Ruleset<SP> {
 
     pub fn arguments(&self) -> &BTreeMap<String, ScalarArgumentTag> {
         &self.arguments
-    }
-
-    pub fn state(&self) -> &RulesetState {
-        &self.state
     }
 
     pub fn output_tag(&self) -> &ComputedScalarTag {

--- a/ayatori/src/flat_representation/ruleset.rs
+++ b/ayatori/src/flat_representation/ruleset.rs
@@ -105,6 +105,12 @@ impl<SP: SessionParameters> PropagatedGroups<SP> {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum RulesetStateChange {
+    Changed,
+    NotChanged,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum RulesetState {
     InProgress,
@@ -219,7 +225,8 @@ impl<SP: SessionParameters> Ruleset<SP> {
         })
     }
 
-    pub fn update_with_banned_party(&mut self, id: &SP::Verifier) {
+    #[must_use]
+    pub fn update_with_banned_party(&mut self, id: &SP::Verifier) -> RulesetStateChange {
         let mut impossible_collects = Vec::new();
         for rule in &mut self.collect_rules {
             rule.update_with_banned_party(id);
@@ -228,17 +235,24 @@ impl<SP: SessionParameters> Ruleset<SP> {
             }
         }
 
-        if !impossible_collects.is_empty() {
+        if impossible_collects.is_empty() {
+            RulesetStateChange::NotChanged
+        } else {
             self.state = RulesetState::ImpossibleToCollect(impossible_collects);
+            RulesetStateChange::Changed
         }
     }
 
-    pub fn update_with_scalar_ready(&mut self, tag: &ScalarTag) {
-        if let ScalarTag::Computed(computed_tag) = tag
+    #[must_use]
+    pub fn update_with_scalar_ready(&mut self, tag: &ScalarTag) -> RulesetStateChange {
+        let state_change = if let ScalarTag::Computed(computed_tag) = tag
             && computed_tag == &self.output_tag
         {
             self.state = RulesetState::ReachedOutput;
-        }
+            RulesetStateChange::Changed
+        } else {
+            RulesetStateChange::NotChanged
+        };
 
         for rule in &mut self.scalar_rules {
             rule.update_with_scalar_ready(tag);
@@ -259,6 +273,8 @@ impl<SP: SessionParameters> Ruleset<SP> {
         for rule in &mut self.send_dm_rules {
             rule.update_with_scalar_ready(tag);
         }
+
+        state_change
     }
 
     pub fn update_with_element_ready(&mut self, tag: &MappingTag, id: &SP::Verifier) {

--- a/book-examples/src/session_runner.rs
+++ b/book-examples/src/session_runner.rs
@@ -40,10 +40,11 @@ where
                     // ANCHOR_END: task_randomized
                     // ANCHOR: task_send
                     Task::Send(task) => {
-                        for message_out in C::send_task_into_messages_out(task)? {
+                        let (update, iter) = C::send_task_into_messages_out(task)?;
+                        for message_out in iter {
                             tx.send(message_out).await.unwrap();
                         }
-                        continue;
+                        update
                     } // ANCHOR_END: task_send
                       // ANCHOR: task_loop_end
                 }


### PR DESCRIPTION
`Session` methods are quite long and complicated. This PR attempts to move logic out of match arms and separate the responsibilities in a clearer way.